### PR TITLE
Fix log flood freezing UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,9 @@ import threading
 import sys
 import io
 
+import eventlet
+eventlet.monkey_patch()
+
 from flask import Flask, render_template, request, jsonify
 from flask_socketio import SocketIO, emit
 from dotenv import load_dotenv, set_key, dotenv_values


### PR DESCRIPTION
## Summary
- keep only latest log lines on the page to prevent blocking
- monkey patch eventlet so start/stop calls don't hang

## Testing
- `python3 -m py_compile main.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_685b83f28d14832691b8baedd38d78b3