### PR TITLE
Fix env display and remove refresh button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# 日本邮政快递追踪与 Bark 通知服务
+
+该项目提供一个基于 Flask + Vue 的简单网页界面，用于追踪日本邮政快递并通过 [Bark](https://github.com/Finb/bark-server) 进行推送通知。界面允许启动/停止追踪脚本和 Bark 服务，并支持在线修改 `.env` 环境变量。
+
+## 安装
+
+1. 安装 Python 依赖：
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. （可选）运行 `install_bark.sh` 下载并配置 Bark Server 可执行文件：
+   ```bash
+   bash install_bark.sh
+   ```
+
+## 使用
+
+1. 在项目根目录新建或编辑 `.env` 文件，设置以下变量：
+   ```ini
+   TRACKING_NUMBER=你的快递单号
+   CHECK_INTERVAL=300
+   BARK_SERVER=https://你的-bark-地址
+   BARK_KEY=你的-bark-key
+   BARK_QUERY_PARAMS=?sound=minuet&level=timeSensitive
+   ```
+2. 启动网页控制台：
+   ```bash
+   python src/app.py
+   ```
+3. 在浏览器访问 `http://localhost:6060`，即可通过界面管理追踪脚本和 Bark 服务。
+
+## 目录结构
+
+- `src/app.py`：Flask 应用及 WebSocket 服务
+- `src/tracker.py`：查询日本邮政物流并推送 Bark 的脚本
+- `src/templates/`：前端页面模板
+- `src/static/`：前端静态资源
+- `install_bark.sh`：自动下载并安装 Bark Server 的脚本
+
+## 许可
+
+本项目基于 MIT 许可证发布，详情参见仓库中的 LICENSE（如有）。

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -23,7 +23,6 @@ const app = createApp({
         const stopScript = () => socket.value.emit('stop_script');
         const startBarkServer = () => socket.value.emit('start_bark_server');
         const stopBarkServer = () => socket.value.emit('stop_bark_server');
-        const requestRefresh = () => socket.value.emit('request_refresh');
 
         const saveEnv = async () => {
             try {
@@ -62,7 +61,6 @@ const app = createApp({
 
             socket.value.on('connect', () => {
                 console.log('Connected to WebSocket server via Vue app.');
-                requestRefresh();
             });
 
             socket.value.on('script_status', (data) => {
@@ -124,7 +122,6 @@ const app = createApp({
             stopScript,
             startBarkServer,
             stopBarkServer,
-            requestRefresh,
             saveEnv,
             trackerLogOutput,
             barkLogOutput,

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -65,9 +65,9 @@
       </div>
     </div>
 
-    <script>
-      window.initialEnvVars = JSON.parse("{{ env_vars | tojson | safe }}");
-    </script>
+      <script>
+        window.initialEnvVars = {{ env_vars | tojson | safe }};
+      </script>
     <script src="/static/app.js"></script>
   </body>
 </html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -12,7 +12,6 @@
     <div id="app" class="container">
       <div class="header">
         <h1>[[ title ]]</h1>
-        <button @click="requestRefresh">手动刷新状态</button>
       </div>
 
       <div class="section">


### PR DESCRIPTION
## Summary
- show env vars even when `.env` is missing
- create `.env` file on update if needed
- send logs to client automatically on connect
- remove manual refresh button and code
- add a Chinese README

## Testing
- `python -m py_compile src/*.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_685b921f1fd48326b3c51d32fdcc836e