### PR TITLE
增加用户系统与树莓派本地funnel部署支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ cython_debug/
 bark-data/
 logs/
 bark-server_*
+.local/
+data/

--- a/README.md
+++ b/README.md
@@ -2,11 +2,24 @@
 
 该项目提供一个基于 Flask + Vue 的简单网页界面，用于追踪日本邮政快递并通过 [Bark](https://github.com/Finb/bark-server) 进行推送通知。界面允许启动/停止追踪脚本和 Bark 服务，并支持在线修改 `.env` 环境变量。
 
+当前版本额外支持更适合树莓派的本地部署方式：
+
+- `tracker.py` 可以优先走本机 Bark 地址
+- 手机 Bark 客户端可以单独使用公网 HTTPS 地址
+- Web 控制台支持启动时自动拉起本地 Bark
+- 支持本地 SQLite 账号与参数绑定，普通用户可注册登录
+- 支持为每个账号保存历史单号档案
+- 适合配合 Tailscale Funnel 暴露 Bark，管理页仍留在内网
+
 ## 功能亮点
 
 - 实时查看追踪脚本和 Bark Server 输出日志
 - 通过浏览器一键启动或停止追踪脚本、Bark Server
+- 支持自动启动本地 Bark 服务
 - 在线编辑 `.env` 配置，无需手动重启
+- 支持管理员后台和普通用户自助门户
+- 支持多用户并行追踪，每个用户绑定自己的 Bark Keys
+- 支持记录每个账号用过的历史单号
 - 支持在 `logs/` 目录中保存历史日志
 - Windows 用户可直接运行 `run.bat` 启动追踪脚本
 
@@ -21,26 +34,112 @@
    bash install_bark.sh
    ```
 
+说明：
+
+- 在树莓派这类环境里，如果官方预编译 `bark-server` 二进制不可用，`install_bark.sh` 会自动退回到 Docker 包装器模式。
+- 如果系统刚装好、只有 `git`，通常还需要先安装 `python3-venv`；若要使用 Docker 包装器，还需要有可用的 `docker`。
+
+## 树莓派本地部署
+
+如果你要在树莓派 Ubuntu 25 上本地运行，并通过 Tailscale Funnel 给手机提供 Bark HTTPS 地址，直接看这份说明：
+
+- [docs/raspberry-pi-funnel.md](/Users/next/Documents/GitHub/jppost-tracker/docs/raspberry-pi-funnel.md)
+
 ## 使用
 
 1. 在项目根目录新建或编辑 `.env` 文件，设置以下变量：
    ```ini
-   TRACKING_NUMBER=你的快递单号
-   CHECK_INTERVAL=300
-   # CHECK_INTERVAL 在网页中可按“分钟 + 秒”输入，仍以秒保存
-   BARK_SERVER=https://你的-bark-地址
-   BARK_KEY=你的-bark-key(一般等于设备token)
-   BARK_QUERY_PARAMS=?sound=minuet&level=timeSensitive
-   # BARK_QUERY_PARAMS 可在网页上直接修改完整字符串
-   # 或通过列表方式逐项编辑，效果等同
-   BARK_URL_ENABLED=1
-   # 是否在推送中附带追踪链接，可在网页中开关
+   # 推荐新部署拆成内外两个地址
+   BARK_SERVER_INTERNAL=http://127.0.0.1:8080
+   BARK_SERVER_PUBLIC=https://你的-bark-地址
+
+   # 兼容旧版配置；若已配置内部/公网地址可留空
+   BARK_SERVER=
+
+   BARK_HEALTH_PATH=/ping
+   BARK_HEALTH_TIMEOUT=15
+   BARK_BIND_ADDRESS=0.0.0.0:8080
+   APP_PORT=6060
+   AUTO_START_BARK_SERVER=0
+
+   # 如果要把 6060 管理页公开出去，建议启用下面这组
+   SECRET_KEY=一段足够长的随机字符串
+   ADMIN_USERNAME=admin
+   ADMIN_PASSWORD_HASH=生成后的密码哈希
+   SESSION_COOKIE_SECURE=1
+   ADMIN_SESSION_HOURS=24
    ```
 2. 启动网页控制台：
    ```bash
-   python src/app.py
+   .venv/bin/python src/app.py
    ```
-3. 在浏览器访问 `http://localhost:6060`，即可通过界面管理追踪脚本和 Bark 服务。
+3. 在浏览器访问 `http://localhost:6060/login`。
+4. 管理员登录后进入后台；普通用户可在登录页直接注册并进入自己的设置页。
+
+重要：
+
+- Bark key 不是通用的。换到新的自建 Bark Server 后，必须在手机 Bark App 里把 Server 指向新地址，再重新复制这台服务器对应的 key。
+- 当前版本支持多端推送，但实现方式是“一个用户保存多个设备各自的 key”，不是“一个 key 自动广播所有设备”。
+- 如果要公开 `6060`，不要再裸暴露旧版本控制台。当前版本支持登录保护，但需要你先配置 `ADMIN_PASSWORD_HASH`。
+
+生成 `ADMIN_PASSWORD_HASH` 的一个简单方法：
+
+```bash
+python3 - <<'PY'
+from werkzeug.security import generate_password_hash
+print(generate_password_hash('替换成你的强密码'))
+PY
+```
+
+补充说明：
+
+- `ADMIN_PASSWORD_HASH` 不会显示在网页环境变量列表里，避免误泄露。
+- 开启登录保护后，`/update_env`、`/remote_bark_status` 和 Socket.IO 控制入口都需要会话认证。
+- 保活探针已改成无鉴权的 `/healthz`，不会因为登录保护把旧的 Render 保活逻辑打坏。
+
+## 本地用户与参数存储
+
+当前版本会把账号、追踪参数和追踪状态持久化到本地 SQLite：
+
+- 数据库路径：`data/app.db`
+- 主表：`accounts`
+- 单号档案表：`tracking_history`
+- 首次启动时，会把旧版 `.env` / `user_profiles` 迁移成一个 `legacy-user-*` 默认追踪用户
+- 如果 `.env` 里配置了 `ADMIN_USERNAME` 和 `ADMIN_PASSWORD_HASH`，还会自动引导出管理员账号
+
+页面行为：
+
+- 管理员登录后进入后台，可管理系统配置、查看日志、维护账号
+- 普通用户登录后只看到自己的“我的快递与 Bark 设置”页面
+- `tracker.py` 会并行读取所有 `tracking_enabled=1` 的用户，不再依赖“当前激活用户”
+
+哪些参数跟用户绑定：
+
+- `TRACKING_NUMBER`
+- `CHECK_INTERVAL`
+- `BARK Keys`
+- `BARK_QUERY_PARAMS`
+- `BARK_URL_ENABLED`
+
+哪些参数仍保存在 `.env`：
+
+- `BARK_SERVER_INTERNAL`
+- `BARK_SERVER_PUBLIC`
+- `BARK_SERVER`
+- `BARK_HEALTH_PATH`
+- `BARK_HEALTH_TIMEOUT`
+- `BARK_BIND_ADDRESS`
+- `PUBLIC_URL`
+- `APP_PORT`
+- `AUTO_START_BARK_SERVER`
+- `ADMIN_USERNAME`
+- `ADMIN_PASSWORD_HASH`
+- `SECRET_KEY`
+
+建议：
+
+- 备份时把 `.env`、`data/app.db`、`bark-data/` 一起保存
+- 不要把 `data/app.db` 提交到 Git 仓库
 
 ## 在 Render 上部署 Bark Server
 
@@ -65,9 +164,11 @@
 1. 打开 iOS Bark 客户端，进入 **Settings**。
 2. 找到 **Server**，填入你的 Render 地址（如 `https://your-bark.onrender.com`）。
 3. 在 **Name** 里给这个 Server 起一个好记的名字（比如 `Render Bark`）。
-4. 返回首页，Bark 会展示你的推送 URL/Key。  
-   - 把 key 填到本项目的 `BARK_KEY`。
-   - 示例推送 URL 形如：`https://your-bark.onrender.com/<token>/<title>/<body>`
+4. 返回首页，Bark 会展示你的推送 URL / Key。  
+   - 普通用户把完整推送 URL 或 key 填到自己门户页里的 `Bark Keys`。
+   - 如果同一个用户要推到多个设备，就把多个设备各自的 key 一行填一个。
+
+如果之后改成树莓派自建的 Bark Server，需要重新在 Bark App 里切换 Server，并复制新的 key；旧 Render key 不能直接复用。
 
 ## 目录结构
 

--- a/deploy/systemd/jppost-tracker-web.service.example
+++ b/deploy/systemd/jppost-tracker-web.service.example
@@ -1,0 +1,19 @@
+[Unit]
+Description=JP Post Tracker Web Console
+After=network-online.target tailscaled.service docker.service
+Wants=network-online.target docker.service
+
+[Service]
+Type=simple
+User=YOUR_USER
+Group=YOUR_USER
+WorkingDirectory=/opt/jppost-tracker
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/jppost-tracker/.venv/bin/python src/app.py
+Restart=always
+RestartSec=5
+KillMode=control-group
+TimeoutStopSec=20
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/raspberry-pi-funnel.md
+++ b/docs/raspberry-pi-funnel.md
@@ -1,0 +1,215 @@
+# 树莓派 Ubuntu 25 本地部署说明
+
+本方案适用于把 `jppost-tracker` 跑在树莓派本机，同时满足两个目标：
+
+1. `tracker.py` 通过树莓派本机的 Bark Server 发送推送。
+2. iPhone 上的 Bark App 不加入 Tailscale，也能通过 Tailscale Funnel 提供的 HTTPS 地址完成配置和接收推送。
+
+## 推荐架构
+
+- `tracker.py` 访问 `BARK_SERVER_INTERNAL=http://127.0.0.1:8080`
+- iPhone Bark App 配置 `BARK_SERVER_PUBLIC=https://<your-node>.<tailnet>.ts.net`
+- Flask 控制台只在局域网或 Tailscale 内访问，不对公网开放
+- Bark Server 对外只公开 `8080`，通过 Funnel 映射成公网 HTTPS
+
+## 1. 安装依赖
+
+如果树莓派当前只装了 `git`，先补系统依赖：
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3-venv
+```
+
+如果你打算使用 `install_bark.sh` 的 Docker 回退方案，还要确保机器上已经有可用的 Docker。
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+bash install_bark.sh
+```
+
+安装脚本会根据 CPU 架构下载对应的 Bark Server，并创建通用入口 `./bark-server`。
+如果官方发布页暂时没有可用的 `arm64` 二进制，脚本会自动改用仓库内置的 Docker 包装器。
+
+## 2. 配置 `.env`
+
+推荐最小配置如下：
+
+```ini
+# tracker.py 优先使用这个地址给本机 Bark 推送
+BARK_SERVER_INTERNAL=http://127.0.0.1:8080
+
+# 手机 Bark 客户端配置这个 HTTPS 地址
+BARK_SERVER_PUBLIC=https://your-node.your-tailnet.ts.net
+
+# 兼容旧版；新部署可以留空
+BARK_SERVER=
+
+BARK_HEALTH_PATH=/ping
+BARK_HEALTH_TIMEOUT=15
+BARK_BIND_ADDRESS=0.0.0.0:8080
+
+# Web 控制台本地端口
+APP_PORT=6060
+
+# 推荐在树莓派服务模式下开启
+AUTO_START_BARK_SERVER=1
+
+# 本地部署通常留空；这是云端保活用的
+PUBLIC_URL=
+```
+
+变量说明：
+
+- `BARK_SERVER_INTERNAL` 给追踪脚本使用，优先级最高。
+- `BARK_SERVER_PUBLIC` 给手机 Bark App 和网页健康检查使用。
+- `BARK_SERVER` 仅作兼容回退。
+- `AUTO_START_BARK_SERVER=1` 时，Web 控制台启动后会自动拉起本地 Bark Server。
+
+## 2.1 本地 SQLite 用户参数
+
+树莓派本地部署现在支持真正的账号体系和多用户并行追踪，默认保存在：
+
+```text
+data/app.db
+```
+
+行为说明：
+
+- 首次启动时会从旧版 `.env` / `user_profiles` 自动迁移出一个 `legacy-user-*` 默认追踪用户
+- 如果 `.env` 中配置了 `ADMIN_USERNAME` 和 `ADMIN_PASSWORD_HASH`，系统会自动引导管理员账号
+- 普通用户可在登录页直接注册
+- 管理员登录后进入后台；普通用户登录后只看到自己的设置页
+- `tracker.py` 会并行追踪所有 `tracking_enabled=1` 的用户，不再依赖“当前激活用户”
+
+当前跟用户绑定的字段：
+
+- `TRACKING_NUMBER`
+- `CHECK_INTERVAL`
+- `Bark Keys`
+- `BARK_QUERY_PARAMS`
+- `BARK_URL_ENABLED`
+- 历史单号档案（保存在 `tracking_history` 表）
+
+系统级字段仍保存在 `.env`：
+
+- `BARK_SERVER_INTERNAL`
+- `BARK_SERVER_PUBLIC`
+- `BARK_SERVER`
+- `BARK_HEALTH_PATH`
+- `BARK_HEALTH_TIMEOUT`
+- `BARK_BIND_ADDRESS`
+- `PUBLIC_URL`
+- `APP_PORT`
+- `AUTO_START_BARK_SERVER`
+
+备份建议：
+
+```bash
+tar czf jppost-backup.tgz .env data/app.db bark-data
+```
+
+## 3. 启用 Tailscale Funnel
+
+首次配置建议：
+
+```bash
+sudo tailscale set --operator=$USER
+sudo tailscale funnel --bg 8080
+tailscale funnel status
+```
+
+期望看到类似：
+
+```text
+https://your-node.your-tailnet.ts.net
+|-- / proxy http://127.0.0.1:8080
+```
+
+验证：
+
+```bash
+curl http://127.0.0.1:8080/ping
+curl https://your-node.your-tailnet.ts.net/ping
+```
+
+说明：
+
+- Funnel 地址自带 HTTPS，不需要单独购买域名。
+- 第一次从公网访问 Funnel 可能会稍慢，健康检查超时默认调到了 15 秒。
+- `tailscale funnel --bg` 的配置会持久化，重启后通常会自动恢复。
+
+## 4. 安装 systemd 服务
+
+仓库提供了示例服务文件：
+
+- [deploy/systemd/jppost-tracker-web.service.example](/Users/next/Documents/GitHub/jppost-tracker/deploy/systemd/jppost-tracker-web.service.example)
+
+参考安装：
+
+```bash
+sudo cp deploy/systemd/jppost-tracker-web.service.example /etc/systemd/system/jppost-tracker-web.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now jppost-tracker-web
+sudo systemctl status jppost-tracker-web
+```
+
+如果你的实际路径不是 `/opt/jppost-tracker`，或运行用户不是当前默认值，先修改示例文件里的 `User`、`Group`、`WorkingDirectory` 和 `ExecStart`。
+
+## 4.1 如果要公开 6060 管理页
+
+不建议裸公开。当前版本已经补上了登录保护，但要先在 `.env` 里配置这组变量：
+
+```ini
+SECRET_KEY=一段足够长的随机字符串
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD_HASH=生成后的密码哈希
+SESSION_COOKIE_SECURE=1
+ADMIN_SESSION_HOURS=24
+```
+
+生成密码哈希：
+
+```bash
+python3 - <<'PY'
+from werkzeug.security import generate_password_hash
+print(generate_password_hash('替换成你的强密码'))
+PY
+```
+
+说明：
+
+- `ADMIN_PASSWORD_HASH` 只建议手工写入 `.env`，不会显示在网页环境变量列表里。
+- 登录保护启用后，`/`、`/update_env`、`/remote_bark_status` 和 Socket.IO 控制入口都要先登录。
+- 程序另外提供了一个无鉴权的 `/healthz`，只用于保活和 systemd / 反向代理健康检查。
+
+## 5. 配置 iPhone Bark
+
+1. 在手机 Bark App 中新增或修改服务器地址为 `BARK_SERVER_PUBLIC`。
+2. 打开对应服务器页面，复制 App 里给出的推送 URL / Key。
+3. 将完整推送 URL 或 key 回填到用户自己的 `Bark Keys`。
+4. 如果同一个用户要推到多个终端，就在每个设备上各自复制一次 key，然后一行填一个。
+5. 用下面的命令验证推送：
+
+```bash
+curl "https://your-node.your-tailnet.ts.net/<key>/测试标题/测试内容"
+```
+
+注意：
+
+- 新自建服务器必须重新注册一次设备并重新复制 key。
+- 旧 Render 服务器、旧 Bark 实例或旧手机记录里的 key 不能直接复用到新服务器。
+- 多端推送不是“一个 key 自动广播”，而是“同一用户保存多个设备各自的 key”。
+- 如果 Bark `/ping` 正常但推送返回 `400`，优先检查的就是这里。
+
+## 6. 运行建议
+
+- 不要把 Flask 管理页 `6060` 直接公开到公网。
+- 如果修改了 `AUTO_START_BARK_SERVER`、`APP_PORT`、`BARK_BIND_ADDRESS` 这类启动参数，重启 Web 服务再生效。
+- 用户自己的单号、Bark Keys 和推送参数都保存在 SQLite，普通用户在自己的设置页就能改。
+- 每个账号保存过的不同单号会写进 `tracking_history`，首页和个人页都能看到单号档案。
+- 网页中的 Bark 健康检查优先使用 `BARK_SERVER_PUBLIC`，这样更接近手机真实访问路径。
+- 使用 systemd 常驻时，建议让服务在 `docker.service` 和 `tailscaled.service` 之后启动，仓库里的示例文件已经按这个顺序处理。
+- 某些环境下，树莓派本机访问自己的 `*.ts.net` Funnel 地址会超时；当前版本会在网页健康检查里自动回退到 `BARK_SERVER_INTERNAL`，并明确标注“本机回退”。
+- 公开 `6060` 前，至少要把 `ADMIN_PASSWORD_HASH`、`SECRET_KEY` 和 `SESSION_COOKIE_SECURE=1` 配好。

--- a/install_bark.sh
+++ b/install_bark.sh
@@ -4,13 +4,36 @@
 set -e
 
 # --- 配置 ---
-# 这是 app.py 文件中硬编码的可执行文件名。
-# 脚本将创建一个指向实际下载文件的符号链接，其名称为此变量的值。
-APP_EXECUTABLE_NAME="bark-server_linux_amd64"
+# 网页控制台会优先查找这个通用可执行文件名。
+# 脚本将创建一个指向实际下载文件的符号链接，避免架构名称写死。
+APP_EXECUTABLE_NAME="bark-server"
 
 # --- 脚本开始 ---
 echo "Bark Server 自动安装脚本"
 echo "-----------------------------------"
+
+install_docker_wrapper() {
+    echo "🐳  预编译二进制不可用，改用 Docker 包装器..."
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "❌ 错误: 当前系统没有可用的 docker 命令，且预编译 Bark Server 下载失败。"
+        exit 1
+    fi
+
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    WRAPPER_SOURCE="${SCRIPT_DIR}/scripts/bark-server-docker-wrapper.sh"
+    if [[ ! -f "$WRAPPER_SOURCE" ]]; then
+        echo "❌ 错误: 未找到 Docker 包装器脚本 '$WRAPPER_SOURCE'。"
+        exit 1
+    fi
+
+    cp "$WRAPPER_SOURCE" "$APP_EXECUTABLE_NAME"
+    chmod +x "$APP_EXECUTABLE_NAME"
+
+    echo ""
+    echo "🎉 已切换为 Docker 包装器模式。"
+    echo "网页控制台仍可正常启动/停止 Bark 服务，但底层将调用 Docker 容器。"
+    return 0
+}
 
 # 1. 检测操作系统和架构
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -64,6 +87,12 @@ fi
 if [ ! -f "$DOWNLOAD_FILENAME" ]; then
     echo "❌ 错误: 下载失败，请检查您的网络或访问 GitHub Releases 页面手动下载。"
     exit 1
+fi
+
+if [[ ! -s "$DOWNLOAD_FILENAME" ]] || grep -q '^Not Found$' "$DOWNLOAD_FILENAME" 2>/dev/null; then
+    rm -f "$DOWNLOAD_FILENAME"
+    install_docker_wrapper
+    exit 0
 fi
 
 # 4. 设置执行权限

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ beautifulsoup4
 python-dotenv
 Flask
 Flask-SocketIO
-eventlet
+gevent

--- a/scripts/bark-server-docker-wrapper.sh
+++ b/scripts/bark-server-docker-wrapper.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMAGE="${BARK_DOCKER_IMAGE:-finab/bark-server}"
+CONTAINER_NAME="${BARK_DOCKER_CONTAINER_NAME:-jppost-bark}"
+ADDR="0.0.0.0:8080"
+DATA_DIR=""
+FORWARD_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -addr)
+      ADDR="${2:?missing value for -addr}"
+      shift 2
+      ;;
+    -data|-d)
+      DATA_DIR="${2:?missing value for -data}"
+      shift 2
+      ;;
+    *)
+      FORWARD_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+HOST="${ADDR%:*}"
+PORT="${ADDR##*:}"
+if [[ "$HOST" == "$ADDR" ]]; then
+  HOST="0.0.0.0"
+fi
+
+if [[ -z "$DATA_DIR" ]]; then
+  DATA_DIR="$(pwd)/bark-data"
+fi
+mkdir -p "$DATA_DIR"
+
+PUBLISH="${PORT}:8080"
+if [[ "$HOST" != "0.0.0.0" ]]; then
+  PUBLISH="${HOST}:${PORT}:8080"
+fi
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT INT TERM
+
+cleanup
+
+docker run \
+  --rm \
+  --name "$CONTAINER_NAME" \
+  -p "$PUBLISH" \
+  -v "$DATA_DIR:/data" \
+  "$IMAGE" \
+  "${FORWARD_ARGS[@]}" &
+
+wait $!

--- a/src/app.py
+++ b/src/app.py
@@ -1,17 +1,35 @@
+import io
 import os
+import sys
+import time
+import secrets
+import urllib.parse
+
+import shutil
 import subprocess
 import threading
-import sys
-import io
-import time
 
-import eventlet
-eventlet.monkey_patch()
+from datetime import timedelta
+from functools import wraps
 
-from flask import Flask, render_template, request, jsonify
-from flask_socketio import SocketIO, emit
-from dotenv import load_dotenv, set_key, dotenv_values
+from flask import Flask, render_template, request, jsonify, redirect, session, url_for
+from flask_socketio import SocketIO, emit, disconnect
+from dotenv import load_dotenv, set_key
 import requests
+
+from storage import (
+    account_to_profile_env,
+    create_account,
+    ensure_storage,
+    get_account,
+    get_account_by_username,
+    list_accounts,
+    load_system_env,
+    parse_bark_keys,
+    register_user,
+    update_account,
+    verify_account_password,
+)
 
 # --- 时区固定为日本 ---
 # Render/容器里即使设置了 TZ，有时也不会自动生效；这里强制设置并调用 tzset。
@@ -26,6 +44,137 @@ if hasattr(time, "tzset"):
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 LOG_DIR = os.path.join(BASE_DIR, 'logs')
 os.makedirs(LOG_DIR, exist_ok=True)
+DOTENV_PATH = os.path.join(BASE_DIR, '.env')
+load_dotenv(DOTENV_PATH)
+ensure_storage(DOTENV_PATH)
+
+SYSTEM_ENV_KEYS = [
+    "BARK_SERVER_INTERNAL",
+    "BARK_SERVER_PUBLIC",
+    "BARK_SERVER",
+    "BARK_HEALTH_PATH",
+    "BARK_HEALTH_TIMEOUT",
+    "BARK_BIND_ADDRESS",
+    "PUBLIC_URL",
+    "APP_PORT",
+    "AUTO_START_BARK_SERVER",
+]
+
+def _first_non_empty(*values: str) -> str:
+    for value in values:
+        if value and str(value).strip():
+            return str(value).strip()
+    return ""
+
+def _env_enabled(name: str, default: str = "0") -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+def get_bark_internal_url() -> str:
+    return _first_non_empty(
+        os.getenv("BARK_SERVER_INTERNAL"),
+        os.getenv("BARK_SERVER"),
+        os.getenv("BARK_SERVER_PUBLIC"),
+    ).rstrip("/")
+
+def get_bark_public_url() -> str:
+    return _first_non_empty(
+        os.getenv("BARK_SERVER_PUBLIC"),
+        os.getenv("BARK_SERVER"),
+        os.getenv("BARK_SERVER_INTERNAL"),
+    ).rstrip("/")
+
+def get_bark_health_timeout() -> int:
+    try:
+        timeout = int(os.getenv("BARK_HEALTH_TIMEOUT", "15"))
+        return timeout if timeout > 0 else 15
+    except Exception:
+        return 15
+
+def get_bark_health_path() -> str:
+    health_path = os.getenv("BARK_HEALTH_PATH", "/ping").strip() or "/ping"
+    return health_path if health_path.startswith("/") else "/" + health_path
+
+def get_bark_bind_address() -> str:
+    return os.getenv("BARK_BIND_ADDRESS", "0.0.0.0:8080").strip() or "0.0.0.0:8080"
+
+def get_bark_executable_candidates():
+    candidates = [
+        os.getenv("BARK_EXECUTABLE", "").strip(),
+        os.path.join(BASE_DIR, "bark-server"),
+        os.path.join(BASE_DIR, "bark-server_linux_arm64"),
+        os.path.join(BASE_DIR, "bark-server_linux_amd64"),
+        os.path.join(BASE_DIR, "bark-server_darwin_arm64"),
+        os.path.join(BASE_DIR, "bark-server_darwin_amd64"),
+        shutil.which("bark-server") or "",
+    ]
+    seen = set()
+    result = []
+    for item in candidates:
+        if item and item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+def get_bark_executable() -> str:
+    for candidate in get_bark_executable_candidates():
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    candidates = get_bark_executable_candidates()
+    return candidates[0] if candidates else os.path.join(BASE_DIR, "bark-server")
+
+def get_app_port() -> int:
+    try:
+        return int(os.getenv("APP_PORT", "6060"))
+    except Exception:
+        return 6060
+
+def get_debug_enabled() -> bool:
+    return _env_enabled("FLASK_DEBUG")
+
+def get_secret_key() -> str:
+    configured = os.getenv("SECRET_KEY", "").strip()
+    return configured or secrets.token_hex(32)
+
+def get_session_cookie_secure() -> bool:
+    return _env_enabled("SESSION_COOKIE_SECURE")
+
+def get_admin_username() -> str:
+    return os.getenv("ADMIN_USERNAME", "admin").strip() or "admin"
+
+def get_admin_session_hours() -> int:
+    try:
+        hours = int(os.getenv("ADMIN_SESSION_HOURS", "24"))
+        return hours if hours > 0 else 24
+    except Exception:
+        return 24
+
+def get_login_max_attempts() -> int:
+    try:
+        attempts = int(os.getenv("ADMIN_LOGIN_MAX_ATTEMPTS", "5"))
+        return attempts if attempts > 0 else 5
+    except Exception:
+        return 5
+
+def get_login_window_seconds() -> int:
+    try:
+        seconds = int(os.getenv("ADMIN_LOGIN_WINDOW_SECONDS", "600"))
+        return seconds if seconds > 0 else 600
+    except Exception:
+        return 600
+
+def current_account():
+    account_id = session.get("account_id")
+    if not account_id:
+        return None
+    return get_account(int(account_id))
+
+
+def is_admin() -> bool:
+    return session.get("account_role") == "admin"
+
+def is_authenticated() -> bool:
+    account = current_account()
+    return bool(account and account.get("login_enabled"))
 
 def _ts() -> str:
     return time.strftime('%Y-%m-%d %H:%M:%S')
@@ -40,15 +189,23 @@ def _append_log(buffer: io.StringIO, filepath: str, event: str, line: str):
     buffer.write(line)
     with open(filepath, 'a') as f:
         f.write(line)
-    socketio.emit(event, {'data': line})
+    try:
+        socketio.emit(event, {'data': line})
+    except Exception:
+        pass
 
 app = Flask(__name__, template_folder=os.path.join(os.path.dirname(__file__), 'templates'),
             static_folder=os.path.join(os.path.dirname(__file__), 'static'))
-app.config['SECRET_KEY'] = 'your_secret_key_here' # 生产环境中请使用更安全的密钥
-socketio = SocketIO(app, async_mode='eventlet', cors_allowed_origins="*") # 允许所有CORS源，生产环境请限制
+app.config.update(
+    SECRET_KEY=get_secret_key(),
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE='Lax',
+    SESSION_COOKIE_SECURE=get_session_cookie_secure(),
+    PERMANENT_SESSION_LIFETIME=timedelta(hours=get_admin_session_hours()),
+)
+socketio = SocketIO(app, async_mode='gevent') # 保持默认同源限制，避免公开管理页时允许任意来源建立 Socket.IO 连接
 
 # --- Bark 服务相关变量 ---
-BARK_EXECUTABLE = os.path.join(BASE_DIR, 'bark-server_linux_amd64')
 BARK_DATA_DIR = os.path.join(BASE_DIR, 'bark-data')
 TRACKER_SCRIPT = os.path.join(os.path.dirname(__file__), 'tracker.py')
 bark_server_process = None
@@ -96,6 +253,8 @@ remote_bark_log_buffer = io.StringIO()
 TRACKER_LOG_FILE = os.path.join(LOG_DIR, 'tracker.log')
 BARK_LOG_FILE = os.path.join(LOG_DIR, 'bark.log')
 REMOTE_BARK_LOG_FILE = os.path.join(LOG_DIR, 'remote_bark.log')
+login_attempts = {}
+login_attempts_lock = threading.Lock()
 
 if os.path.exists(TRACKER_LOG_FILE):
     with open(TRACKER_LOG_FILE, 'r') as f:
@@ -111,40 +270,370 @@ def log_remote_bark(line: str):
     """写入远程 Bark 健康检测日志，并推送到前端。"""
     _append_log(remote_bark_log_buffer, REMOTE_BARK_LOG_FILE, 'remote_bark_log', _ensure_nl(line))
 
-# --- 环境变量文件路径 ---
-DOTENV_PATH = os.path.join(BASE_DIR, '.env')
-load_dotenv(DOTENV_PATH)
+def log_tracker(line: str):
+    _append_log(tracker_log_buffer, TRACKER_LOG_FILE, 'tracker_log', _ensure_nl(line))
 
+def log_bark(line: str):
+    _append_log(bark_log_buffer, BARK_LOG_FILE, 'bark_log', _ensure_nl(line))
+
+def get_client_ip() -> str:
+    forwarded = request.headers.get("X-Forwarded-For", "").split(",")[0].strip()
+    if forwarded:
+        return forwarded
+    real_ip = request.headers.get("X-Real-IP", "").strip()
+    return real_ip or (request.remote_addr or "unknown")
+
+def _prune_login_attempts(entries, now):
+    window = get_login_window_seconds()
+    return [ts for ts in entries if now - ts < window]
+
+def record_login_failure(ip: str):
+    now = time.time()
+    with login_attempts_lock:
+        entries = _prune_login_attempts(login_attempts.get(ip, []), now)
+        entries.append(now)
+        login_attempts[ip] = entries
+
+def clear_login_failures(ip: str):
+    with login_attempts_lock:
+        login_attempts.pop(ip, None)
+
+def login_is_rate_limited(ip: str) -> bool:
+    now = time.time()
+    with login_attempts_lock:
+        entries = _prune_login_attempts(login_attempts.get(ip, []), now)
+        login_attempts[ip] = entries
+        return len(entries) >= get_login_max_attempts()
+
+def build_next_target(default: str = "/") -> str:
+    candidate = (request.args.get("next") or request.form.get("next") or default).strip()
+    if not candidate.startswith("/") or candidate.startswith("//"):
+        return default
+    return candidate
+
+def current_request_target() -> str:
+    query = request.query_string.decode().strip()
+    return request.path + (f"?{query}" if query else "")
+
+def wants_json_response() -> bool:
+    accept = request.headers.get("Accept", "")
+    return (
+        request.is_json
+        or request.path.startswith("/api/")
+        or request.path.startswith("/update_env")
+        or request.path.startswith("/remote_bark_status")
+        or "application/json" in accept
+    )
+
+def unauthorized_response():
+    if wants_json_response():
+        return jsonify({"status": "error", "message": "未登录或会话已过期。"}), 401
+    return redirect(url_for('login', next=current_request_target()))
+
+def login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not is_authenticated():
+            return unauthorized_response()
+        return view(*args, **kwargs)
+    return wrapped
+
+def admin_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not is_authenticated():
+            return unauthorized_response()
+        if not is_admin():
+            if wants_json_response():
+                return jsonify({"status": "error", "message": "需要管理员权限。"}), 403
+            return redirect(url_for('index'))
+        return view(*args, **kwargs)
+    return wrapped
+
+def socket_admin_required(handler):
+    @wraps(handler)
+    def wrapped(*args, **kwargs):
+        if not is_authenticated() or not is_admin():
+            emit('auth_error', {'message': '未登录、会话已过期，或缺少管理员权限。'})
+            disconnect()
+            return
+        return handler(*args, **kwargs)
+    return wrapped
+
+@app.before_request
+def require_auth():
+    if request.endpoint in {'login', 'register', 'logout', 'healthz', 'static'}:
+        return None
+    if request.path.startswith('/socket.io'):
+        return None
+    if not is_authenticated():
+        return unauthorized_response()
+    return None
+
+@app.after_request
+def add_security_headers(response):
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "same-origin")
+    if request.path in {'/', '/login', '/register', '/logout', '/update_env', '/remote_bark_status'}:
+        response.headers["Cache-Control"] = "no-store"
+    return response
+
+@app.route('/healthz', methods=['GET'])
+def healthz():
+    return jsonify({"status": "ok"})
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    next_target = build_next_target()
+    if is_authenticated():
+        return redirect(next_target)
+
+    error = None
+    if request.method == 'POST':
+        ip = get_client_ip()
+        username = request.form.get('username', '').strip()
+        password = request.form.get('password', '')
+        if login_is_rate_limited(ip):
+            error = "登录失败次数过多，请稍后再试。"
+        else:
+            account = get_account_by_username(username, include_secret=True)
+            is_valid = (
+                account is not None
+                and account.get("login_enabled")
+                and verify_account_password(account, password)
+            )
+            if is_valid:
+                clear_login_failures(ip)
+                session.clear()
+                session.permanent = True
+                session['account_id'] = account['id']
+                session['account_role'] = account['role']
+                session['account_username'] = account['username']
+                return redirect(next_target)
+            record_login_failure(ip)
+            error = "用户名或密码错误。"
+
+    return render_template(
+        'login.html',
+        error=error,
+        next_target=next_target,
+        admin_username=get_admin_username(),
+    )
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    next_target = build_next_target()
+    if is_authenticated():
+        return redirect(next_target)
+
+    if request.method == 'GET':
+        return render_template('register.html', error=None, next_target=next_target)
+
+    form = request.form
+    try:
+        account = register_user(
+            {
+                "username": form.get("register_username", ""),
+                "display_name": form.get("register_display_name", ""),
+                "password": form.get("register_password", ""),
+            }
+        )
+        session.clear()
+        session.permanent = True
+        session['account_id'] = account['id']
+        session['account_role'] = account['role']
+        session['account_username'] = account['username']
+        return redirect(next_target)
+    except Exception as exc:
+        return render_template(
+            'register.html',
+            error=str(exc),
+            next_target=next_target,
+        ), 400
+
+@app.route('/logout', methods=['POST'])
+def logout():
+    session.clear()
+    return redirect(url_for('login'))
+
+def build_viewer_state():
+    account = current_account()
+    return {
+        "account": account,
+        "role": account["role"] if account else "",
+        "is_admin": bool(account and account["role"] == "admin"),
+        "username": account["username"] if account else "",
+        "display_name": account["display_name"] if account else "",
+    }
+
+def build_user_state():
+    users = list_accounts()
+    return {
+        "users": users,
+        "tracked_count": len([user for user in users if user.get("tracking_enabled")]),
+        "login_count": len([user for user in users if user.get("login_enabled")]),
+    }
+
+def build_system_env():
+    system_env = load_system_env(DOTENV_PATH, SYSTEM_ENV_KEYS)
+    return {key: system_env.get(key, "") for key in SYSTEM_ENV_KEYS}
+
+def build_bark_help_state():
+    return {
+        "public_url": get_bark_public_url(),
+        "internal_url": get_bark_internal_url(),
+        "health_path": get_bark_health_path(),
+    }
+
+def check_bark_endpoint(bark_url: str, label: str = "BARK") -> dict:
+    health_url = f"{bark_url}{get_bark_health_path()}"
+    log_remote_bark(_fmt('[REMOTE_BARK]', f"CHECK {label} {health_url}"))
+    start = time.time()
+    try:
+        resp = requests.get(health_url, timeout=get_bark_health_timeout())
+        latency_ms = int((time.time() - start) * 1000)
+        log_remote_bark(_fmt('[REMOTE_BARK]', f"OK {label} HTTP {resp.status_code} {latency_ms}ms"))
+        return {
+            "configured": True,
+            "url": bark_url,
+            "checked_url": bark_url,
+            "ok": resp.status_code == 200,
+            "status_code": resp.status_code,
+            "latency_ms": latency_ms,
+            "error": None if resp.status_code == 200 else f"HTTP {resp.status_code}",
+            "fallback_used": False,
+            "note": None,
+        }
+    except Exception as e:
+        latency_ms = int((time.time() - start) * 1000)
+        log_remote_bark(_fmt('[REMOTE_BARK]', f"ERROR {label} {latency_ms}ms {e}"))
+        return {
+            "configured": True,
+            "url": bark_url,
+            "checked_url": bark_url,
+            "ok": False,
+            "status_code": None,
+            "latency_ms": latency_ms,
+            "error": str(e),
+            "fallback_used": False,
+            "note": None,
+        }
+
+def _parse_bark_query_params(query_string: str) -> dict:
+    query_string = str(query_string or "").strip()
+    if not query_string:
+        return {}
+    result = {}
+    for part in query_string.lstrip("?").split("&"):
+        if not part:
+            continue
+        key, _, value = part.partition("=")
+        result[urllib.parse.unquote(key)] = urllib.parse.unquote(value)
+    return result
+
+def _bool_from_input(value, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+def build_bark_test_account(source_account: dict | None, data) -> dict:
+    source = source_account or {}
+    if hasattr(data, "getlist"):
+        bark_url_enabled = 'bark_url_enabled' in data if ('bark_url_enabled' in data or source) else False
+        bark_keys = data.get("bark_keys", "")
+    else:
+        bark_url_enabled = _bool_from_input(
+            data.get("bark_url_enabled"),
+            default=bool(source.get("bark_url_enabled")),
+        )
+        bark_keys = data.get("bark_keys") or data.get("bark_key", "")
+
+    return {
+        "display_name": str(data.get("display_name", source.get("display_name", "")) or "").strip() or source.get("display_name") or "当前用户",
+        "tracking_number": str(data.get("tracking_number", source.get("tracking_number", "")) or "").strip(),
+        "bark_keys": bark_keys or source.get("bark_keys") or source.get("bark_key", ""),
+        "bark_query_params": str(data.get("bark_query_params", source.get("bark_query_params", "")) or "").strip(),
+        "bark_url_enabled": bark_url_enabled,
+    }
+
+def extract_bark_test_message(data, *, default_title: str, default_body: str) -> tuple[str, str]:
+    title = str(data.get("test_title", default_title) or default_title).strip() or default_title
+    body = str(data.get("test_body", default_body) or default_body).strip() or default_body
+    return title, body
+
+def send_bark_test_push(account: dict, title: str = "测试推送", body: str = "Bark 设置已生效。") -> dict:
+    bark_server = get_bark_internal_url()
+    bark_keys = parse_bark_keys(account.get("bark_keys") or account.get("bark_key"))
+    if not bark_server:
+        raise ValueError("未配置 Bark 服务地址。")
+    if not bark_keys:
+        raise ValueError("当前用户还没有配置 Bark Keys。")
+
+    params = _parse_bark_query_params(account.get("bark_query_params", ""))
+    if account.get("bark_url_enabled") and account.get("tracking_number"):
+        params["url"] = (
+            "https://trackings.post.japanpost.jp/services/srv/search/direct"
+            f"?reqCodeNo1={account['tracking_number']}&searchKind=S002&locale=ja"
+        )
+
+    timeout = get_bark_health_timeout()
+    if len(bark_keys) == 1:
+        title_enc = urllib.parse.quote(title, safe="")
+        body_enc = urllib.parse.quote(body, safe="")
+        query = urllib.parse.urlencode(params, doseq=True)
+        suffix = f"?{query}" if query else ""
+        resp = requests.get(f"{bark_server}/{bark_keys[0]}/{title_enc}/{body_enc}{suffix}", timeout=timeout)
+    else:
+        payload = {"title": title, "body": body, "device_keys": bark_keys, **params}
+        resp = requests.post(f"{bark_server}/push", json=payload, timeout=timeout)
+
+    return {
+        "ok": 200 <= resp.status_code < 300,
+        "status_code": resp.status_code,
+        "devices": len(bark_keys),
+        "response_text": resp.text[:500],
+    }
 
 @app.route('/')
+@login_required
 def index():
-    """渲染主页面，并加载当前的环境变量和分离的历史日志。"""
-    env_vars = dotenv_values(DOTENV_PATH)
-    default_keys = [
-        "TRACKING_NUMBER",
-        "CHECK_INTERVAL",
-        "BARK_SERVER",
-        "BARK_KEY",
-        "BARK_HEALTH_PATH",
-        "BARK_QUERY_PARAMS",
-        "BARK_URL_ENABLED",
-        "PUBLIC_URL",
-    ]
-    # 以 .env 的非空值为准；若 .env 未包含或为空，则回退到进程环境变量（Render Dashboard 设置）
-    display_env = {}
-    for k in default_keys:
-        val = env_vars.get(k)
-        if val is not None and str(val).strip() != "":
-            display_env[k] = val
-        else:
-            display_env[k] = os.getenv(k, "")
-    initial_tracker_log = tracker_log_buffer.getvalue()
-    initial_bark_log = bark_log_buffer.getvalue()
-    return render_template('index.html', env_vars=display_env, initial_tracker_log=initial_tracker_log, initial_bark_log=initial_bark_log)
+    viewer_state = build_viewer_state()
+    account = viewer_state["account"]
+    bark_help = build_bark_help_state()
+    if viewer_state["is_admin"]:
+        system_env = build_system_env()
+        user_state = build_user_state()
+        initial_tracker_log = tracker_log_buffer.getvalue()
+        initial_bark_log = bark_log_buffer.getvalue()
+        return render_template(
+            'index.html',
+            viewer_state=viewer_state,
+            env_vars=system_env,
+            user_state=user_state,
+            bark_help=bark_help,
+            initial_tracker_log=initial_tracker_log,
+            initial_bark_log=initial_bark_log,
+        )
+
+    profile_env = account_to_profile_env(account)
+    return render_template(
+        'user_portal.html',
+        viewer_state=viewer_state,
+        account=account,
+        profile_env=profile_env,
+        bark_help=bark_help,
+        message=request.args.get("message", "").strip(),
+        status=request.args.get("status", "").strip() or "success",
+    )
 
 @socketio.on('connect')
-def test_connect():
+def test_connect(auth=None):
     """客户端连接时发送当前所有服务的状态。"""
+    if not is_authenticated() or not is_admin():
+        return False
     print('Client connected', flush=True)
     emit('script_status', {'running': script_process is not None and script_process.poll() is None})
     public_url = get_public_url()
@@ -173,9 +662,9 @@ def read_script_output():
         return
     try:
         for line in iter(stream.readline, ''):
-            _append_log(tracker_log_buffer, TRACKER_LOG_FILE, 'tracker_log', _fmt('[TRACKER]', line.rstrip()))
+            log_tracker(_fmt('[TRACKER]', line.rstrip()))
     except Exception as e:
-        _append_log(tracker_log_buffer, TRACKER_LOG_FILE, 'tracker_log', _fmt('[TRACKER]', f"ERROR: 读取脚本输出时发生错误: {e}"))
+        log_tracker(_fmt('[TRACKER]', f"ERROR: 读取脚本输出时发生错误: {e}"))
     finally:
         # 停止保活线程
         stop_keepalive()
@@ -183,9 +672,35 @@ def read_script_output():
             script_process.stdout.close()
         
         return_code = script_process.wait() if script_process else 'N/A'
-        _append_log(tracker_log_buffer, TRACKER_LOG_FILE, 'tracker_log', _fmt('[TRACKER]', f"脚本已停止，返回码: {return_code}"))
+        log_tracker(_fmt('[TRACKER]', f"脚本已停止，返回码: {return_code}"))
         socketio.emit('script_status', {'running': False})
         script_process = None
+
+def start_tracker_script(start_reason: str = "manual") -> bool:
+    global script_process, script_thread
+    if script_process is not None and script_process.poll() is None:
+        log_tracker(_fmt('[TRACKER]', "脚本已经在运行中。"))
+        socketio.emit('script_status', {'running': True})
+        return False
+
+    action = "自动启动" if start_reason == "auto" else "正在启动"
+    log_tracker(_fmt('[SYSTEM]', f"{action}追踪脚本..."))
+    try:
+        script_process = subprocess.Popen(
+            [sys.executable, '-u', TRACKER_SCRIPT],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+        )
+        log_tracker(_fmt('[TRACKER]', "脚本已启动。"))
+        socketio.emit('script_status', {'running': True})
+        start_keepalive()
+
+        script_thread = threading.Thread(target=read_script_output, daemon=True)
+        script_thread.start()
+        return True
+    except Exception as e:
+        log_tracker(_fmt('[TRACKER]', f"启动脚本失败: {e}"))
+        socketio.emit('script_status', {'running': False})
+        return False
 
 def keepalive_loop():
     """追踪脚本运行期间定时自 ping，避免 Render free 休眠。"""
@@ -207,7 +722,7 @@ def keepalive_loop():
         # 开始 ping
         keepalive_state = "pinging"
         emit_keepalive_status(True, True, public_url)
-        url = f"{public_url}/remote_bark_status"
+        url = f"{public_url}/healthz"
         try:
             resp = requests.get(url, timeout=5)
             keepalive_last_code = resp.status_code
@@ -234,7 +749,7 @@ def start_keepalive():
     emit_keepalive_status(True, True, public_url)
     # 启动时立即 ping 一次
     try:
-        resp = requests.get(f"{public_url}/remote_bark_status", timeout=5)
+        resp = requests.get(f"{public_url}/healthz", timeout=5)
         keepalive_last_code = resp.status_code
         keepalive_last_error = None if resp.ok else f"HTTP {resp.status_code}"
         keepalive_state = "ok" if resp.ok else "error"
@@ -247,7 +762,7 @@ def start_keepalive():
 
     keepalive_thread = threading.Thread(target=keepalive_loop, daemon=True)
     keepalive_thread.start()
-    _append_log(tracker_log_buffer, TRACKER_LOG_FILE, 'tracker_log', _fmt('[SYSTEM]', f"Render 保活已启用，每 {interval}s ping {public_url}"))
+    log_tracker(_fmt('[SYSTEM]', f"Render 保活已启用，每 {interval}s ping {public_url}"))
 
 def stop_keepalive():
     global keepalive_thread, keepalive_state
@@ -259,41 +774,23 @@ def stop_keepalive():
         emit_keepalive_status(False, bool(public_url), public_url)
 
 @socketio.on('start_script')
+@socket_admin_required
 def start_script():
     """启动 Python 追踪脚本。"""
-    global script_process, script_thread
-    if script_process is not None and script_process.poll() is None:
-        emit('tracker_log', {'data': _fmt('[TRACKER]', "脚本已经在运行中。")})
-        emit('script_status', {'running': True})
-        return
-
-    emit('tracker_log', {'data': _fmt('[SYSTEM]', "正在启动追踪脚本...")})
-    try:
-        script_process = subprocess.Popen(
-            [sys.executable, '-u', TRACKER_SCRIPT],
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
-        )
-        emit('tracker_log', {'data': _fmt('[TRACKER]', "脚本已启动。")})
-        emit('script_status', {'running': True})
-        start_keepalive()
-        
-        script_thread = threading.Thread(target=read_script_output, daemon=True)
-        script_thread.start()
-    except Exception as e:
-        emit('tracker_log', {'data': _fmt('[TRACKER]', f"启动脚本失败: {e}")})
-        emit('script_status', {'running': False})
+    start_tracker_script()
 
 @socketio.on('stop_script')
+@socket_admin_required
 def stop_script():
     """终止 Python 追踪脚本。"""
     global script_process
     if script_process is not None and script_process.poll() is None:
-        emit('tracker_log', {'data': _fmt('[SYSTEM]', "终止追踪脚本信号已发送。")})
+        log_tracker(_fmt('[SYSTEM]', "终止追踪脚本信号已发送。"))
         script_process.terminate()
         stop_keepalive()
     else:
-        emit('tracker_log', {'data': _fmt('[TRACKER]', "脚本未运行。")})
-        emit('script_status', {'running': False})
+        log_tracker(_fmt('[TRACKER]', "脚本未运行。"))
+        socketio.emit('script_status', {'running': False})
 
 # --- Bark 服务控制 ---
 
@@ -306,64 +803,77 @@ def read_bark_output():
         return
     try:
         for line in iter(stream.readline, ''):
-            _append_log(bark_log_buffer, BARK_LOG_FILE, 'bark_log', _fmt('[BARK]', line.rstrip()))
+            log_bark(_fmt('[BARK]', line.rstrip()))
     except Exception as e:
-        _append_log(bark_log_buffer, BARK_LOG_FILE, 'bark_log', _fmt('[BARK]', f"ERROR: 读取服务输出时发生错误: {e}"))
+        log_bark(_fmt('[BARK]', f"ERROR: 读取服务输出时发生错误: {e}"))
     finally:
         if bark_server_process and bark_server_process.stdout:
             bark_server_process.stdout.close()
             
         return_code = bark_server_process.wait() if bark_server_process else 'N/A'
-        _append_log(bark_log_buffer, BARK_LOG_FILE, 'bark_log', _fmt('[BARK]', f"服务已停止，返回码: {return_code}"))
+        log_bark(_fmt('[BARK]', f"服务已停止，返回码: {return_code}"))
         socketio.emit('bark_server_status', {'running': False})
         bark_server_process = None
 
-@socketio.on('start_bark_server')
-def start_bark_server():
-    """启动 Bark 服务。"""
+def start_local_bark_server(start_reason: str = "manual") -> bool:
     global bark_server_process, bark_server_thread
     if bark_server_process is not None and bark_server_process.poll() is None:
-        emit('bark_log', {'data': _fmt('[BARK]', "服务已经在运行中。")})
-        emit('bark_server_status', {'running': True})
-        return
+        log_bark(_fmt('[BARK]', "服务已经在运行中。"))
+        socketio.emit('bark_server_status', {'running': True})
+        return False
+
+    action = "自动启动" if start_reason == "auto" else "正在启动"
+    log_bark(_fmt('[SYSTEM]', f"{action} Bark 服务..."))
+
+    bark_executable = get_bark_executable()
+    if not (os.path.isfile(bark_executable) and os.access(bark_executable, os.X_OK)):
+        tried = ", ".join(get_bark_executable_candidates())
+        log_bark(_fmt('[BARK]', f"启动失败: 未找到可执行文件。已尝试: {tried}"))
+        socketio.emit('bark_server_status', {'running': False})
+        return False
     
-    emit('bark_log', {'data': _fmt('[SYSTEM]', "正在启动 Bark 服务...")})
     try:
         os.makedirs(BARK_DATA_DIR, exist_ok=True)
         bark_server_process = subprocess.Popen(
-            [BARK_EXECUTABLE, '-addr', '0.0.0.0:8080', '-data', BARK_DATA_DIR],
+            [bark_executable, '-addr', get_bark_bind_address(), '-data', BARK_DATA_DIR],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
         )
-        emit('bark_log', {'data': _fmt('[BARK]', "服务已启动。")})
-        emit('bark_server_status', {'running': True})
+        log_bark(_fmt('[BARK]', f"服务已启动。监听地址: {get_bark_bind_address()}"))
+        socketio.emit('bark_server_status', {'running': True})
         
         bark_server_thread = threading.Thread(target=read_bark_output, daemon=True)
         bark_server_thread.start()
-    except FileNotFoundError:
-        emit('bark_log', {'data': _fmt('[BARK]', f"启动失败: 未找到可执行文件 '{BARK_EXECUTABLE}'。")})
-        emit('bark_server_status', {'running': False})
+        return True
     except Exception as e:
-        emit('bark_log', {'data': _fmt('[BARK]', f"启动服务失败: {e}")})
-        emit('bark_server_status', {'running': False})
+        log_bark(_fmt('[BARK]', f"启动服务失败: {e}"))
+        socketio.emit('bark_server_status', {'running': False})
+        return False
+
+@socketio.on('start_bark_server')
+@socket_admin_required
+def start_bark_server():
+    """启动 Bark 服务。"""
+    start_local_bark_server()
 
 @socketio.on('stop_bark_server')
+@socket_admin_required
 def stop_bark_server():
     """终止 Bark 服务。"""
     global bark_server_process
     if bark_server_process is not None and bark_server_process.poll() is None:
-        emit('bark_log', {'data': _fmt('[SYSTEM]', "终止 Bark 服务信号已发送。")})
+        log_bark(_fmt('[SYSTEM]', "终止 Bark 服务信号已发送。"))
         bark_server_process.terminate()
     else:
-        emit('bark_log', {'data': _fmt('[BARK]', "服务未运行。")})
-        emit('bark_server_status', {'running': False})
+        log_bark(_fmt('[BARK]', "服务未运行。"))
+        socketio.emit('bark_server_status', {'running': False})
 
 # --- 环境变量更新 ---
 
 @app.route('/update_env', methods=['POST'])
+@admin_required
 def update_env():
-    """更新 .env 文件中的变量。"""
     data = request.get_json()
-    if not data:
+    if data is None:
         return jsonify({"status": "error", "message": "无效的请求数据"}), 400
 
     if len(data) == 0:
@@ -372,90 +882,230 @@ def update_env():
     if not os.path.exists(DOTENV_PATH):
         open(DOTENV_PATH, 'a').close()
 
-    updated_count = 0; errors = []
-    for key, value in data.items():
+    system_changes = {key: value for key, value in data.items() if key in SYSTEM_ENV_KEYS}
+    if not system_changes:
+        return jsonify({"status": "error", "message": "没有可更新的系统配置。"}), 400
+
+    updated_count = 0
+    errors = []
+    for key, value in system_changes.items():
         try:
             set_key(DOTENV_PATH, key, value)
             updated_count += 1
         except Exception as e:
             errors.append(f"更新 {key} 失败: {e}")
 
-    # 将本次更新的非空值同步到当前进程环境变量；
-    # 空值不覆盖已有进程环境变量，避免与 Render/本地 shell 配置冲突。
-    for key, value in data.items():
+    for key, value in system_changes.items():
         if isinstance(value, str) and value.strip() == "":
             continue
         os.environ[key] = str(value)
 
     # 若更新了保活相关参数，刷新前端状态显示
-    if "PUBLIC_URL" in data or "KEEPALIVE_INTERVAL" in data:
+    if "PUBLIC_URL" in system_changes or "KEEPALIVE_INTERVAL" in system_changes:
         public_url = get_public_url()
         emit_keepalive_status(keepalive_is_running(), bool(public_url), public_url)
 
     if updated_count > 0:
-        message = f"成功更新 {updated_count} 个环境变量。"
+        message = f"成功更新 {updated_count} 个系统环境变量。"
         if errors: message += " 部分变量更新失败: " + "; ".join(errors)
-        socketio.emit('tracker_log', {'data': _fmt('[SYSTEM]', message) + _fmt('[SYSTEM]', "请注意：更新的环境变量将在脚本下次启动时生效。")})
-        return jsonify({"status": "success", "message": message})
-    else:
-        return jsonify({"status": "error", "message": "没有变量被更新或发生错误: " + "; ".join(errors)}), 500
+        log_tracker(_fmt('[SYSTEM]', message))
+        log_tracker(_fmt('[SYSTEM]', "请注意：更新的环境变量将在脚本下次启动时生效。"))
+        return jsonify({"status": "success", "message": message, "env_vars": build_system_env(), "bark_help": build_bark_help_state()})
+    return jsonify({"status": "error", "message": "没有变量被更新或发生错误: " + "; ".join(errors)}), 500
+
+@app.route('/api/users', methods=['GET'])
+@admin_required
+def api_list_users():
+    return jsonify(build_user_state())
+
+
+@app.route('/api/users', methods=['POST'])
+@admin_required
+def api_create_user():
+    data = request.get_json() or {}
+    try:
+        user = create_account(data)
+        return jsonify({
+            "status": "success",
+            "message": "用户已创建。",
+            "user": user,
+            "user_state": build_user_state(),
+        })
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 400
+
+
+@app.route('/api/users/<int:user_id>', methods=['GET'])
+@admin_required
+def api_get_user(user_id: int):
+    user = get_account(user_id)
+    if not user:
+        return jsonify({"status": "error", "message": "用户不存在。"}), 404
+    return jsonify({"status": "success", "user": user})
+
+
+@app.route('/api/users/<int:user_id>', methods=['PUT'])
+@admin_required
+def api_update_user(user_id: int):
+    data = request.get_json() or {}
+    try:
+        user = update_account(user_id, data, actor_role="admin")
+        return jsonify({
+            "status": "success",
+            "message": "用户已更新。",
+            "user": user,
+            "user_state": build_user_state(),
+        })
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 400
+
+
+@app.route('/api/users/<int:user_id>/test_push', methods=['POST'])
+@admin_required
+def api_user_test_push(user_id: int):
+    user = get_account(user_id)
+    if not user:
+        return jsonify({"status": "error", "message": "用户不存在。"}), 404
+    try:
+        payload = request.get_json() or {}
+        test_account = build_bark_test_account(user, payload)
+        title, body = extract_bark_test_message(
+            payload,
+            default_title="测试推送",
+            default_body=f"{user['display_name']} 的 Bark 设置已生效。",
+        )
+        result = send_bark_test_push(test_account, title=title, body=body)
+        if result["ok"]:
+            return jsonify({"status": "success", "message": f"测试推送已发送到 {result['devices']} 个设备。"})
+        return jsonify({"status": "error", "message": f"推送失败，HTTP {result['status_code']}"}), 400
+    except Exception as exc:
+        return jsonify({"status": "error", "message": str(exc)}), 400
+
+
+@app.route('/api/me', methods=['GET'])
+@login_required
+def api_me():
+    account = current_account()
+    return jsonify({"status": "success", "user": account})
+
+
+@app.route('/api/me', methods=['PUT'])
+@login_required
+def api_update_me():
+    account = current_account()
+    data = request.get_json() or {}
+    try:
+        user = update_account(account["id"], data, actor_role=account["role"], actor_id=account["id"])
+        return jsonify({
+            "status": "success",
+            "message": "个人资料已更新。",
+            "user": user,
+        })
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 400
+
+
+@app.route('/me/update', methods=['POST'])
+@login_required
+def me_update_form():
+    account = current_account()
+    try:
+        update_account(
+            account["id"],
+            {
+                "display_name": request.form.get("display_name", ""),
+                "note": request.form.get("note", ""),
+                "tracking_number": request.form.get("tracking_number", ""),
+                "check_interval": request.form.get("check_interval", "300"),
+                "bark_keys": request.form.get("bark_keys", ""),
+                "bark_query_params": request.form.get("bark_query_params", ""),
+                "bark_url_enabled": 'bark_url_enabled' in request.form,
+                "new_password": request.form.get("new_password", ""),
+            },
+            actor_role=account["role"],
+            actor_id=account["id"],
+        )
+        return redirect(url_for('index', status='success', message='资料已保存。'))
+    except Exception as exc:
+        return redirect(url_for('index', status='error', message=str(exc)))
+
+
+@app.route('/me/test-push', methods=['POST'])
+@login_required
+def me_test_push():
+    account = current_account()
+    try:
+        test_account = build_bark_test_account(account, request.form)
+        title, body = extract_bark_test_message(
+            request.form,
+            default_title="测试推送",
+            default_body="你的 Bark 设置已生效。",
+        )
+        result = send_bark_test_push(test_account, title=title, body=body)
+        if result["ok"]:
+            return redirect(url_for('index', status='success', message=f"测试推送已发送到 {result['devices']} 个设备。"))
+        return redirect(url_for('index', status='error', message=f"推送失败，HTTP {result['status_code']}"))
+    except Exception as exc:
+        return redirect(url_for('index', status='error', message=str(exc)))
 
 # --- 远程 Bark 服务状态 ---
 
 @app.route('/remote_bark_status', methods=['GET'])
+@admin_required
 def remote_bark_status():
     """
-    检查远程 Bark Server 是否可访问。
+    检查 Bark 地址是否可访问。
     返回:
-      configured: 是否配置了 BARK_SERVER
-      url: 当前 BARK_SERVER
+      configured: 是否配置了 Bark 地址
+      url: 当前检测地址
       ok: 是否成功访问(HTTP 200)
       status_code: 响应码(如有)
       latency_ms: 请求耗时
       error: 错误信息(如有)
     """
-    bark_url = os.getenv("BARK_SERVER", "").strip()
-    if not bark_url:
+    public_bark_url = get_bark_public_url()
+    if not public_bark_url:
         return jsonify({
             "configured": False,
             "url": "",
+            "checked_url": "",
             "ok": False,
             "status_code": None,
             "latency_ms": None,
-            "error": "未配置 BARK_SERVER"
+            "error": "未配置 BARK_SERVER_PUBLIC / BARK_SERVER / BARK_SERVER_INTERNAL",
+            "fallback_used": False,
+            "note": None,
         })
+    result = check_bark_endpoint(public_bark_url, label="PUBLIC")
+    internal_bark_url = get_bark_internal_url()
+    if result["ok"] or result["status_code"] is not None or not internal_bark_url or internal_bark_url == public_bark_url:
+        return jsonify(result)
 
-    # 去掉末尾 /，避免双斜杠，并按配置健康路径检测
-    bark_url = bark_url.rstrip("/")
-    health_path = os.getenv("BARK_HEALTH_PATH", "/").strip() or "/"
-    if not health_path.startswith("/"):
-        health_path = "/" + health_path
-    health_url = f"{bark_url}{health_path}"
-    log_remote_bark(_fmt('[REMOTE_BARK]', f"CHECK {health_url}"))
-    start = time.time()
-    try:
-        resp = requests.get(health_url, timeout=5)
-        latency_ms = int((time.time() - start) * 1000)
-        log_remote_bark(_fmt('[REMOTE_BARK]', f"OK HTTP {resp.status_code} {latency_ms}ms"))
-        return jsonify({
-            "configured": True,
-            "url": bark_url,
-            "ok": resp.status_code == 200,
-            "status_code": resp.status_code,
-            "latency_ms": latency_ms,
-            "error": None if resp.status_code == 200 else f"HTTP {resp.status_code}"
-        })
-    except Exception as e:
-        latency_ms = int((time.time() - start) * 1000)
-        log_remote_bark(_fmt('[REMOTE_BARK]', f"ERROR {latency_ms}ms {e}"))
-        return jsonify({
-            "configured": True,
-            "url": bark_url,
-            "ok": False,
-            "status_code": None,
-            "latency_ms": latency_ms,
-            "error": str(e)
-        })
+    log_remote_bark(_fmt('[REMOTE_BARK]', f"PUBLIC 自检失败，回退到 INTERNAL {internal_bark_url}"))
+    fallback_result = check_bark_endpoint(internal_bark_url, label="INTERNAL")
+    fallback_result["url"] = public_bark_url
+    fallback_result["fallback_used"] = True
+    if fallback_result["ok"]:
+        fallback_result["note"] = f"公网地址在本机自检失败，已回退到本地地址 {internal_bark_url}"
+        fallback_result["error"] = result["error"]
+    else:
+        fallback_result["note"] = f"公网地址和本地地址自检都失败了。公网错误: {result['error']}"
+        if fallback_result["error"]:
+            fallback_result["error"] = f"{result['error']} | INTERNAL: {fallback_result['error']}"
+    return jsonify(fallback_result)
+
+def auto_start_configured_services():
+    auto_start_bark = _env_enabled("AUTO_START_BARK_SERVER")
+
+    if auto_start_bark:
+        log_bark(_fmt('[SYSTEM]', "检测到 AUTO_START_BARK_SERVER=1，准备启动 Bark 服务。"))
+        start_local_bark_server(start_reason="auto")
+    if _env_enabled("AUTO_START_TRACKER"):
+        log_tracker(_fmt('[SYSTEM]', "AUTO_START_TRACKER 已停用。当前版本不会在 Web 启动时自动开始追踪，请在后台手动启动脚本。"))
 
 if __name__ == '__main__':
-    socketio.run(app, host='0.0.0.0', port=6060, debug=True, use_reloader=False)
+    auto_start_configured_services()
+    try:
+        socketio.run(app, host='0.0.0.0', port=get_app_port(), debug=get_debug_enabled(), use_reloader=False)
+    except KeyboardInterrupt:
+        pass

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,136 +1,82 @@
 const { createApp, ref, onMounted, nextTick, computed, watch } = Vue;
 
-// 限制前端保存的日志条数，避免大量日志导致页面阻塞
 const MAX_LOG_LINES = 500;
 
 const app = createApp({
     setup() {
-        // --- 响应式状态定义 ---
-        const title = ref('快递追踪器与通知服务控制台 (Vue.js)');
+        const title = ref('快递追踪控制台');
         const socket = ref(null);
+        const page = ref('home');
+        const logTab = ref('remote');
 
-        const page = ref('home'); // home | env | logs
-        const logTab = ref('remote'); // remote | tracker | bark
-
+        const viewer = ref(window.initialViewerState || {});
+        const barkHelp = ref(window.initialBarkHelp || {});
         const envVars = ref(window.initialEnvVars || {});
-        // 记录初始快照，用于只提交变更字段，避免覆盖 Render 环境变量
         const originalEnvVars = ref({ ...envVars.value });
-        // 分秒输入框
-        const rawInterval = Number(envVars.value.CHECK_INTERVAL || 0);
-        const intervalMin = ref(Math.floor(rawInterval / 60));
-        const intervalSec = ref(rawInterval % 60);
-        // 环境变量中文说明
+        const initialUserState = window.initialUserState || { users: [], tracked_count: 0, login_count: 0 };
+
         const envDesc = {
-            TRACKING_NUMBER: '快递单号',
-            CHECK_INTERVAL: '查询间隔(分和秒)',
-            BARK_SERVER: 'Bark 地址',
-            BARK_KEY: 'Bark Key/设备 Token',
-            BARK_HEALTH_PATH: '远程 Bark 健康路径',
-            BARK_QUERY_PARAMS: '通知额外参数',
-            BARK_URL_ENABLED: '在通知中附带追踪链接',
-            PUBLIC_URL: '控制台公网地址(保活用)'
+            BARK_SERVER_INTERNAL: '追踪脚本访问的 Bark 地址',
+            BARK_SERVER_PUBLIC: '手机 Bark 客户端访问的 HTTPS 地址',
+            BARK_SERVER: '兼容旧版的单 Bark 地址',
+            BARK_HEALTH_PATH: 'Bark 健康检测路径',
+            BARK_HEALTH_TIMEOUT: 'Bark 健康检测超时(秒)',
+            BARK_BIND_ADDRESS: '本地 Bark 监听地址',
+            PUBLIC_URL: '控制台公网地址(保活用)',
+            APP_PORT: 'Web 控制台端口',
+            AUTO_START_BARK_SERVER: 'Web 启动时自动拉起本地 Bark'
         };
-        // 将 BARK_QUERY_PARAMS 解析为对象便于编辑
-        const parseQuery = (str) => {
-            const q = {};
-            if (!str) return q;
-            str.replace(/^\?/, '').split('&').forEach(part => {
-                if (!part) return;
-                const [k, v = ''] = part.split('=');
-                q[decodeURIComponent(k)] = decodeURIComponent(v);
-            });
-            return q;
-        };
-        const buildQuery = (obj) => {
-            const parts = Object.keys(obj).map(k => `${encodeURIComponent(k)}=${encodeURIComponent(obj[k])}`);
-            return parts.length ? '?' + parts.join('&') : '';
-        };
-        const barkParams = ref(parseQuery(envVars.value.BARK_QUERY_PARAMS));
-        const includeUrl = ref(envVars.value.BARK_URL_ENABLED !== '0');
-        delete barkParams.value.url;
-        const newParam = ref('');
-        const paramOptions = {
-            sound: {
-                description: '通知铃声',
-                values: [
-                    { value: 'alarm', label: 'alarm (闹钟)' },
-                    { value: 'anticipate', label: 'anticipate (期待)' },
-                    { value: 'bell', label: 'bell (铃声)' },
-                    { value: 'birdsong', label: 'birdsong (鸟鸣)' },
-                    { value: 'bloom', label: 'bloom (绽放)' },
-                    { value: 'calypso', label: 'calypso' },
-                    { value: 'chime', label: 'chime (提示音)' },
-                    { value: 'choo', label: 'choo' },
-                    { value: 'descent', label: 'descent' },
-                    { value: 'electronic', label: 'electronic' },
-                    { value: 'fanfare', label: 'fanfare (号角)' },
-                    { value: 'glass', label: 'glass' },
-                    { value: 'gotosleep', label: 'gotosleep' },
-                    { value: 'healthnotification', label: 'healthnotification' },
-                    { value: 'horn', label: 'horn (喇叭)' },
-                    { value: 'ladder', label: 'ladder' },
-                    { value: 'mailsent', label: 'mailsent' },
-                    { value: 'minuet', label: 'minuet (小步舞曲)' },
-                    { value: 'multiwayinvitation', label: 'multiwayinvitation' },
-                    { value: 'newmail', label: 'newmail' },
-                    { value: 'newsflash', label: 'newsflash (新闻)' },
-                    { value: 'noir', label: 'noir' },
-                    { value: 'paymentsuccess', label: 'paymentsuccess' },
-                    { value: 'shake', label: 'shake' },
-                    { value: 'sherwoodforest', label: 'sherwoodforest' },
-                    { value: 'silence', label: 'silence (静音)' },
-                    { value: 'spell', label: 'spell' },
-                    { value: 'suspense', label: 'suspense' },
-                    { value: 'telegraph', label: 'telegraph' },
-                    { value: 'tiptoes', label: 'tiptoes' },
-                    { value: 'typewriters', label: 'typewriters' },
-                    { value: 'update', label: 'update' }
-                ]
-            },
-            level: {
-                description: '推送级别',
-                values: [
-                    { value: 'active', label: 'active (默认)' },
-                    { value: 'timeSensitive', label: 'timeSensitive (专注)' },
-                    { value: 'passive', label: 'passive (静默)' },
-                    { value: 'critical', label: 'critical (重要警告)' }
-                ]
-            },
-            badge: { description: '角标数字', values: [] },
-            autoCopy: { description: '自动复制', values: [{ value: '1', label: '1 (开启)' }] },
-            copy: { description: '复制的内容', values: [] },
-            group: { description: '消息分组', values: [] },
-            icon: { description: '自定义图标URL', values: [] },
-            isArchive: { description: '是否保存', values: [{ value: '1', label: '1 (保存)' }] },
-            call: { description: '重复铃声', values: [{ value: '1', label: '1 (开启)' }] },
-            action: { description: '点击无弹窗', values: [{ value: 'none', label: 'none' }] },
-            volume: { description: '重要警告音量(0-10)', values: [] }
-        };
-        const availableParams = Vue.computed(() => {
-            const result = {};
-            for (const k in paramOptions) {
-                if (!(k in barkParams.value)) {
-                    result[k] = paramOptions[k];
-                }
-            }
-            return result;
+
+        const pickDefaultUserId = (list = []) =>
+            list.find((user) => user.role !== 'admin')?.id || list[0]?.id || null;
+
+        const buildUserForm = (user = {}) => ({
+            id: user.id || null,
+            username: user.username || '',
+            display_name: user.display_name || user.name || '',
+            role: user.role || 'user',
+            note: user.note || '',
+            tracking_number: user.tracking_number || '',
+            check_interval: Number(user.check_interval || 300),
+            bark_keys: user.bark_keys || user.bark_key || '',
+            bark_query_params: user.bark_query_params || '?sound=minuet&level=timeSensitive',
+            bark_url_enabled: Boolean(user.bark_url_enabled),
+            login_enabled: user.login_enabled !== false,
+            tracking_enabled: user.tracking_enabled !== false,
+            new_password: '',
+            test_title: '测试推送',
+            test_body: '这是 Bark 参数预览消息，用来确认通知样式、声音和链接效果。',
         });
 
-        // 保持文本字段与表格参数同步
-        watch(barkParams, (val) => {
-            const combined = buildQuery(val);
-            if (envVars.value.BARK_QUERY_PARAMS !== combined) {
-                envVars.value.BARK_QUERY_PARAMS = combined;
-            }
-        }, { deep: true });
-
-        watch(() => envVars.value.BARK_QUERY_PARAMS, (val) => {
-            const current = buildQuery(barkParams.value);
-            if (val !== current) {
-                barkParams.value = parseQuery(val);
-            }
+        const users = ref(initialUserState.users || []);
+        const selectedUserId = ref(pickDefaultUserId(initialUserState.users || []));
+        const userForm = ref(
+            buildUserForm((initialUserState.users || []).find((user) => user.id === selectedUserId.value) || {})
+        );
+        const newUserForm = ref({
+            username: '',
+            display_name: '',
+            password: '',
+            role: 'user',
+            login_enabled: true,
+            tracking_enabled: true,
         });
+        const createUserExpanded = ref(false);
+        const userMessage = ref({ text: '', type: '' });
         const envMessage = ref({ text: '', type: '' });
+        const sendingTestPush = ref(false);
+
+        const countBarkKeys = (value) =>
+            String(value || '')
+                .split(/\n+/)
+                .map((item) => item.trim())
+                .filter(Boolean).length;
+
+        const trackedUsersCount = computed(() => users.value.filter((user) => user.tracking_enabled).length);
+        const loginUsersCount = computed(() => users.value.filter((user) => user.login_enabled).length);
+        const trackedNumbersCount = computed(() =>
+            users.value.reduce((total, user) => total + Number(user.tracking_history_count || 0), 0)
+        );
 
         const script = ref({ running: false, logs: [] });
         const keepalive = ref({
@@ -144,73 +90,131 @@ const app = createApp({
         });
         const bark = ref({ running: false, logs: [] });
         const remoteBarkLogs = ref([]);
-
-        // Bark 面板 Tab：local / remote
-        const barkTab = ref('local');
         const remoteBark = ref({
             loading: false,
             configured: false,
             url: '',
+            checked_url: '',
             ok: false,
             status_code: null,
             latency_ms: null,
             error: null,
+            fallback_used: false,
+            note: null,
             checked_at: ''
         });
-
-        // 远程 Bark 刷新模式（默认手动）
-        const remoteRefreshMode = ref('manual'); // manual | auto
-        // 已应用的间隔（用于定时器）
+        const remoteRefreshMode = ref('manual');
         const remoteAutoMin = ref(0);
         const remoteAutoSec = ref(30);
-        // 输入草稿（只有点保存才应用）
-        const remoteAutoMinDraft = ref(remoteAutoMin.value);
-        const remoteAutoSecDraft = ref(remoteAutoSec.value);
+        const remoteAutoMinDraft = ref(0);
+        const remoteAutoSecDraft = ref(30);
         let remoteAutoTimer = null;
 
         const trackerLogOutput = ref(null);
         const barkLogOutput = ref(null);
         const remoteBarkLogOutput = ref(null);
 
-        // --- 方法 ---
-        const startScript = () => socket.value.emit('start_script');
-        const stopScript = () => socket.value.emit('stop_script');
-        const startBarkServer = () => socket.value.emit('start_bark_server');
-        const stopBarkServer = () => socket.value.emit('stop_bark_server');
+        const selectedUser = computed(() => users.value.find((user) => user.id === selectedUserId.value) || null);
+        const selectedUserTrackingState = computed(() => {
+            const user = selectedUser.value;
+            if (!user) {
+                return { tone: 'pending', label: '未选择账号' };
+            }
+            if (user.role === 'admin' && !user.tracking_enabled && !user.tracking_number) {
+                return { tone: 'pending', label: '管理账号' };
+            }
+            if (!user.tracking_number) {
+                return { tone: 'pending', label: '待填写单号' };
+            }
+            if (!user.tracking_enabled) {
+                return { tone: 'pending', label: '追踪已关闭' };
+            }
+            if (!script.value.running) {
+                return { tone: 'pending', label: '待启动脚本' };
+            }
+            if (user.last_error) {
+                return { tone: 'error', label: '最近轮询异常' };
+            }
+            return { tone: 'ok', label: '追踪中' };
+        });
+        const selectedUserDeviceCount = computed(() => countBarkKeys(selectedUser.value?.bark_keys));
+        const selectedUserHistoryCount = computed(() => Number(selectedUser.value?.tracking_history_count || 0));
+        const selectedUserHistory = computed(() => selectedUser.value?.tracking_history_preview || []);
+        const selectedUserLatestStatus = computed(() => {
+            const user = selectedUser.value;
+            if (!user) {
+                return '请选择一个账号开始编辑追踪信息。';
+            }
+            if (user.last_error) {
+                return user.last_error;
+            }
+            if (user.last_tracking_info) {
+                return user.last_tracking_info;
+            }
+            if (!user.tracking_number) {
+                return '还没有填写日本邮政单号。';
+            }
+            if (!user.tracking_enabled) {
+                return '单号已保存，但当前账号没有启用追踪。';
+            }
+            if (!script.value.running) {
+                return '单号已保存，等你手动启动追踪脚本后就会开始轮询。';
+            }
+            return '单号已保存，等待下一次轮询结果。';
+        });
+
+        const syncUserState = (state) => {
+            users.value = state?.users || [];
+            if (!selectedUserId.value || !users.value.some((user) => user.id === selectedUserId.value)) {
+                selectedUserId.value = pickDefaultUserId(users.value);
+            }
+            userForm.value = buildUserForm(users.value.find((user) => user.id === selectedUserId.value) || {});
+        };
+
+        const redirectToLogin = () => {
+            const next = encodeURIComponent(window.location.pathname + window.location.search);
+            window.location.href = `/login?next=${next}`;
+        };
+
+        const handleApiResponse = async (response) => {
+            if (response.status === 401) {
+                redirectToLogin();
+                return null;
+            }
+            return response.json();
+        };
+
+        const scrollToBottom = (element) => {
+            if (!element) return;
+            const shouldScroll = element.scrollHeight - element.clientHeight <= element.scrollTop + 50;
+            if (shouldScroll) {
+                element.scrollTop = element.scrollHeight;
+            }
+        };
+
+        const startScript = () => socket.value?.emit('start_script');
+        const stopScript = () => socket.value?.emit('stop_script');
+        const startBarkServer = () => socket.value?.emit('start_bark_server');
+        const stopBarkServer = () => socket.value?.emit('stop_bark_server');
 
         const fetchRemoteBarkStatus = async () => {
             remoteBark.value.loading = true;
             try {
                 const response = await fetch('/remote_bark_status', { cache: 'no-store' });
-                const contentType = response.headers.get('content-type') || '';
-                let data = null;
-                if (contentType.includes('application/json')) {
-                    data = await response.json();
-                } else {
-                    const text = await response.text();
-                    data = {
-                        configured: Boolean(envVars.value.BARK_SERVER),
-                        url: envVars.value.BARK_SERVER || '',
-                        ok: false,
-                        status_code: response.status,
-                        latency_ms: null,
-                        error: `远程状态接口返回非 JSON：HTTP ${response.status}`
-                    };
-                    // 将部分返回体记录到控制台，便于排查
-                    console.warn('remote_bark_status non-json response:', text.slice(0, 200));
-                }
+                const data = await handleApiResponse(response);
+                if (!data) return;
                 remoteBark.value = {
                     ...remoteBark.value,
                     ...data,
                     loading: false,
                     checked_at: new Date().toLocaleString()
                 };
-            } catch (e) {
+            } catch (error) {
                 remoteBark.value = {
                     ...remoteBark.value,
                     loading: false,
                     ok: false,
-                    error: String(e),
+                    error: String(error),
                     checked_at: new Date().toLocaleString()
                 };
             }
@@ -239,35 +243,8 @@ const app = createApp({
             }
         };
 
-        const pasteTrackingNumber = async () => {
-            try {
-                if (navigator.clipboard && navigator.clipboard.readText) {
-                    const text = await navigator.clipboard.readText();
-                    if (text) {
-                        envVars.value.TRACKING_NUMBER = text.trim();
-                        return;
-                    }
-                }
-            } catch (e) {
-                console.warn('clipboard read failed', e);
-            }
-            // 兼容非 HTTPS/无权限场景：不弹窗，提示用户手动粘贴
-            envMessage.value = {
-                text: '浏览器不允许读取剪贴板，请在快递单号输入框手动粘贴(Cmd/Ctrl+V)。',
-                type: 'error'
-            };
-        };
-
-        const clearTrackingNumber = () => {
-            envVars.value.TRACKING_NUMBER = '';
-        };
-
         const saveEnv = async () => {
             try {
-                envVars.value.BARK_QUERY_PARAMS = buildQuery(barkParams.value);
-                envVars.value.BARK_URL_ENABLED = includeUrl.value ? '1' : '0';
-                envVars.value.CHECK_INTERVAL = String(intervalMin.value * 60 + Number(intervalSec.value));
-                // 只发送发生变化的键
                 const changed = {};
                 for (const [key, value] of Object.entries(envVars.value)) {
                     if (originalEnvVars.value[key] !== value) {
@@ -279,70 +256,144 @@ const app = createApp({
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(changed)
                 });
-                const result = await response.json();
+                const result = await handleApiResponse(response);
+                if (!result) return;
                 envMessage.value = {
                     text: result.message,
                     type: result.status === 'success' ? 'success' : 'error'
                 };
-                if (result.status === 'success') {
-                    originalEnvVars.value = { ...envVars.value };
+                if (result.status === 'success' && result.env_vars) {
+                    envVars.value = { ...result.env_vars };
+                    originalEnvVars.value = { ...result.env_vars };
+                }
+                if (result.status === 'success' && result.bark_help) {
+                    barkHelp.value = { ...result.bark_help };
                 }
             } catch (error) {
-                console.error('Error updating env:', error);
-                envMessage.value = {
-                    text: '保存环境变量时发生错误。',
-                    type: 'error'
+                envMessage.value = { text: '保存系统设置时发生错误。', type: 'error' };
+            }
+        };
+
+        const selectUser = (userId) => {
+            selectedUserId.value = userId;
+            userMessage.value = { text: '', type: '' };
+        };
+
+        const createUser = async () => {
+            try {
+                const response = await fetch('/api/users', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ...newUserForm.value })
+                });
+                const result = await handleApiResponse(response);
+                if (!result) return;
+                userMessage.value = {
+                    text: result.message,
+                    type: result.status === 'success' ? 'success' : 'error'
                 };
-            }
-        };
-
-        const addParam = () => {
-            if (newParam.value && !(newParam.value in barkParams.value)) {
-                const opt = paramOptions[newParam.value];
-                barkParams.value[newParam.value] = opt.values[0] || '';
-                newParam.value = '';
-            }
-        };
-
-        const removeParam = (param) => {
-            delete barkParams.value[param];
-        };
-
-        const scrollToBottom = (element) => {
-            if (element) {
-                // 滚动前检查是否需要滚动，给用户自己向上查看日志的机会
-                const shouldScroll = element.scrollHeight - element.clientHeight <= element.scrollTop + 50;
-                if (shouldScroll) {
-                    element.scrollTop = element.scrollHeight;
+                if (result.status === 'success') {
+                    syncUserState(result.user_state);
+                    if (result.user) {
+                        selectedUserId.value = result.user.id;
+                    }
+                    newUserForm.value = {
+                        username: '',
+                        display_name: '',
+                        password: '',
+                        role: 'user',
+                        login_enabled: true,
+                        tracking_enabled: true,
+                    };
+                    createUserExpanded.value = false;
                 }
+            } catch (error) {
+                userMessage.value = { text: '创建账号时发生错误。', type: 'error' };
             }
         };
 
-        // --- 生命周期钩子 ---
-        onMounted(() => {
-            socket.value = io();
+        const saveUser = async () => {
+            if (!selectedUserId.value) return;
+            try {
+                const response = await fetch(`/api/users/${selectedUserId.value}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ...userForm.value })
+                });
+                const result = await handleApiResponse(response);
+                if (!result) return;
+                userMessage.value = {
+                    text: result.message,
+                    type: result.status === 'success' ? 'success' : 'error'
+                };
+                if (result.status === 'success') {
+                    syncUserState(result.user_state);
+                    if (result.user) {
+                        userForm.value = buildUserForm(result.user);
+                    }
+                }
+            } catch (error) {
+                userMessage.value = { text: '保存账号时发生错误。', type: 'error' };
+            }
+        };
 
-            socket.value.on('connect', () => {
-                console.log('Connected to WebSocket server via Vue app.');
+        const sendUserTestPush = async () => {
+            if (!selectedUserId.value || sendingTestPush.value) return;
+            sendingTestPush.value = true;
+            try {
+                const response = await fetch(`/api/users/${selectedUserId.value}/test_push`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ...userForm.value })
+                });
+                const result = await handleApiResponse(response);
+                if (!result) return;
+                userMessage.value = {
+                    text: result.message,
+                    type: result.status === 'success' ? 'success' : 'error'
+                };
+            } catch (error) {
+                userMessage.value = { text: '发送测试推送失败。', type: 'error' };
+            } finally {
+                sendingTestPush.value = false;
+            }
+        };
+
+        watch(selectedUserId, (nextUserId) => {
+            userForm.value = buildUserForm(users.value.find((user) => user.id === nextUserId) || {});
+        });
+
+        watch(remoteRefreshMode, (mode) => {
+            if (mode === 'auto') {
+                remoteAutoMinDraft.value = remoteAutoMin.value;
+                remoteAutoSecDraft.value = remoteAutoSec.value;
+                startRemoteAutoTimer();
+                fetchRemoteBarkStatus();
+            } else {
+                clearRemoteAutoTimer();
+            }
+        });
+
+        onMounted(() => {
+            socket.value = io({ withCredentials: true });
+
+            socket.value.on('connect_error', (error) => {
+                const message = String(error?.message || error || '').toLowerCase();
+                if (message.includes('unauthorized') || message.includes('auth')) {
+                    redirectToLogin();
+                }
             });
+            socket.value.on('auth_error', () => redirectToLogin());
 
             socket.value.on('script_status', (data) => {
                 script.value.running = data.running;
             });
             socket.value.on('keepalive_status', (data) => {
-                keepalive.value.running = data.running;
-                keepalive.value.configured = data.configured;
-                keepalive.value.url = data.url || '';
-                keepalive.value.state = data.state || 'idle';
-                keepalive.value.last_code = data.last_code ?? null;
-                keepalive.value.last_error = data.last_error ?? null;
-                keepalive.value.last_at = data.last_at || '';
+                keepalive.value = { ...keepalive.value, ...data };
             });
             socket.value.on('bark_server_status', (data) => {
                 bark.value.running = data.running;
             });
-
-            // 增量日志
             socket.value.on('tracker_log', async (data) => {
                 script.value.logs.push(data.data.replace(/\n/g, '<br>'));
                 if (script.value.logs.length > MAX_LOG_LINES) {
@@ -359,29 +410,18 @@ const app = createApp({
                 await nextTick();
                 scrollToBottom(barkLogOutput.value);
             });
-
-            // 完整日志 (用于刷新)
             socket.value.on('full_tracker_log', async (data) => {
-                const lines = data.data ? data.data.split('\n').map(line => line.replace(/\n/g, '<br>')) : [];
-                if (lines.length > MAX_LOG_LINES) {
-                    script.value.logs = lines.slice(-MAX_LOG_LINES);
-                } else {
-                    script.value.logs = lines;
-                }
+                const lines = data.data ? data.data.split('\n').map((line) => line.replace(/\n/g, '<br>')) : [];
+                script.value.logs = lines.length > MAX_LOG_LINES ? lines.slice(-MAX_LOG_LINES) : lines;
                 await nextTick();
                 scrollToBottom(trackerLogOutput.value);
             });
             socket.value.on('full_bark_log', async (data) => {
-                const lines = data.data ? data.data.split('\n').map(line => line.replace(/\n/g, '<br>')) : [];
-                if (lines.length > MAX_LOG_LINES) {
-                    bark.value.logs = lines.slice(-MAX_LOG_LINES);
-                } else {
-                    bark.value.logs = lines;
-                }
+                const lines = data.data ? data.data.split('\n').map((line) => line.replace(/\n/g, '<br>')) : [];
+                bark.value.logs = lines.length > MAX_LOG_LINES ? lines.slice(-MAX_LOG_LINES) : lines;
                 await nextTick();
                 scrollToBottom(barkLogOutput.value);
             });
-
             socket.value.on('remote_bark_log', async (data) => {
                 remoteBarkLogs.value.push(data.data.replace(/\n/g, '<br>'));
                 if (remoteBarkLogs.value.length > MAX_LOG_LINES) {
@@ -390,76 +430,63 @@ const app = createApp({
                 await nextTick();
                 scrollToBottom(remoteBarkLogOutput.value);
             });
-
             socket.value.on('full_remote_bark_log', async (data) => {
-                const lines = data.data ? data.data.split('\n').map(line => line.replace(/\n/g, '<br>')) : [];
+                const lines = data.data ? data.data.split('\n').map((line) => line.replace(/\n/g, '<br>')) : [];
                 remoteBarkLogs.value = lines.length > MAX_LOG_LINES ? lines.slice(-MAX_LOG_LINES) : lines;
                 await nextTick();
                 scrollToBottom(remoteBarkLogOutput.value);
             });
 
-            // 页面加载后自动检测一次远程健康状态
             fetchRemoteBarkStatus();
         });
 
-        // 切换到远程 tab 时先检查一次
-        watch(barkTab, (val) => {
-            if (val === 'remote' && !remoteBark.value.loading && !remoteBark.value.checked_at) {
-                fetchRemoteBarkStatus();
-            }
-        });
-
-        // 刷新模式变化时重置定时器；切到自动时用已应用的间隔
-        watch(remoteRefreshMode, (mode) => {
-            if (mode === 'auto') {
-                // 进入自动模式时同步草稿为当前已应用值
-                remoteAutoMinDraft.value = remoteAutoMin.value;
-                remoteAutoSecDraft.value = remoteAutoSec.value;
-                startRemoteAutoTimer();
-                fetchRemoteBarkStatus();
-            } else {
-                clearRemoteAutoTimer();
-            }
-        });
-
-        // 返回给模板使用的所有变量和方法
         return {
             title,
             page,
             logTab,
+            viewer,
+            barkHelp,
             envVars,
+            envDesc,
             envMessage,
+            users,
+            selectedUserId,
+            selectedUser,
+            selectedUserTrackingState,
+            selectedUserDeviceCount,
+            selectedUserHistoryCount,
+            selectedUserHistory,
+            selectedUserLatestStatus,
+            userForm,
+            newUserForm,
+            createUserExpanded,
+            userMessage,
+            sendingTestPush,
+            trackedUsersCount,
+            loginUsersCount,
+            trackedNumbersCount,
             script,
             keepalive,
             bark,
-            remoteBarkLogs,
-            barkTab,
             remoteBark,
+            remoteBarkLogs,
+            remoteRefreshMode,
+            remoteAutoMinDraft,
+            remoteAutoSecDraft,
             startScript,
             stopScript,
             startBarkServer,
             stopBarkServer,
             fetchRemoteBarkStatus,
-            remoteRefreshMode,
-            remoteAutoMinDraft,
-            remoteAutoSecDraft,
             applyRemoteAutoInterval,
-            pasteTrackingNumber,
-            clearTrackingNumber,
             saveEnv,
+            selectUser,
+            createUser,
+            saveUser,
+            sendUserTestPush,
             trackerLogOutput,
             barkLogOutput,
             remoteBarkLogOutput,
-            barkParams,
-            envDesc,
-            paramOptions,
-            availableParams,
-            includeUrl,
-            intervalMin,
-            intervalSec,
-            newParam,
-            addParam,
-            removeParam
         };
     }
 });

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1,779 +1,1819 @@
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap");
+
+:root {
+  --font-body: "Manrope", "Segoe UI", sans-serif;
+  --font-display: "Outfit", "Manrope", "Segoe UI", sans-serif;
+  --bg-0: #eef4ff;
+  --bg-1: #dce8ff;
+  --bg-2: #f8f4ff;
+  --bg-3: #fff2e6;
+  --ink-strong: #10203c;
+  --ink: #213450;
+  --ink-soft: #61728c;
+  --line: rgba(132, 156, 196, 0.24);
+  --line-strong: rgba(97, 129, 186, 0.34);
+  --glass: rgba(255, 255, 255, 0.34);
+  --glass-strong: rgba(255, 255, 255, 0.56);
+  --glass-deep: rgba(255, 255, 255, 0.18);
+  --navy: rgba(13, 25, 46, 0.88);
+  --blue: #5f7fff;
+  --blue-deep: #3458df;
+  --cyan: #79d8ff;
+  --mint: #7ce8d2;
+  --green: #25b26f;
+  --red: #ea5b73;
+  --amber: #ffb95f;
+  --shadow-lg: 0 34px 96px rgba(58, 84, 133, 0.18);
+  --shadow-md: 0 18px 46px rgba(52, 73, 116, 0.12);
+  --shadow-sm: 0 10px 24px rgba(52, 73, 116, 0.1);
+  --radius-xl: 34px;
+  --radius-lg: 28px;
+  --radius-md: 22px;
+  --radius-sm: 16px;
+  --blur-xl: blur(42px) saturate(185%);
+  --blur-lg: blur(30px) saturate(170%);
+  --blur-md: blur(18px) saturate(150%);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: light;
+}
+
 body {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  margin: 20px;
-  background-color: #f6f7fb;
-  color: #0f172a;
-  line-height: 1.5;
-}
-.container {
-  max-width: 1200px;
-  margin: auto;
-  background: #fff;
+  margin: 0;
+  min-height: 100vh;
   padding: 24px;
-  border-radius: 12px;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
-}
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid #e5e7eb;
-  padding-bottom: 12px;
-  margin-bottom: 18px;
-}
-.header h1 {
-  color: #0f172a;
-  margin: 0;
-}
-.header button {
-  background-color: #111827;
-  color: white;
-  border: none;
-  padding: 10px 15px;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 14px;
-  transition: background-color 0.2s, transform 0.05s;
-}
-.header button:hover {
-  background-color: #0b1220;
+  font-family: var(--font-body);
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 12% 18%, rgba(96, 146, 255, 0.26), transparent 30%),
+    radial-gradient(circle at 84% 14%, rgba(255, 176, 226, 0.22), transparent 25%),
+    radial-gradient(circle at 72% 82%, rgba(255, 199, 123, 0.24), transparent 28%),
+    conic-gradient(from 190deg at 50% 50%, rgba(255, 255, 255, 0.18), rgba(221, 235, 255, 0.06), rgba(255, 255, 255, 0.18)),
+    linear-gradient(145deg, var(--bg-0) 0%, var(--bg-1) 40%, var(--bg-2) 72%, #edf7ff 100%);
+  background-attachment: fixed;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  position: relative;
+  overflow-x: hidden;
 }
 
-/* Header 里的 page tabs 不走通用 header button 样式 */
-.header .page-tab {
-  background: transparent;
-  color: #111827;
-  border: 0;
-  border-right: 1px solid #e5e7eb;
-  padding: 9px 14px;
-  border-radius: 0;
-}
-.header .page-tabs .page-tab:last-child {
-  border-right: 0;
-}
-.header .page-tab:hover:not(.active) {
-  background: #eef2f7;
-}
-.header .page-tab.active {
-  background: #111827;
-  color: #fff;
-}
-.flex-container {
-  display: flex;
-  gap: 20px;
-  align-items: stretch;
-}
-.flex-child {
-  flex: 1;
-  display: flex;
-  min-width: 0;
-}
-h2 {
-  color: #0f172a;
-  border-bottom: 1px solid #ddd;
-  padding-bottom: 5px;
-}
-h3 {
-  margin-top: 0;
-  color: #0f172a;
-}
-.section {
-  padding: 16px;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
-  background-color: #ffffff;
-  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.04);
-}
-.service-panel {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  min-height: 520px;
-  min-width: 0;
-}
-.service-panel-body {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-}
-.log-container {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-width: 0;
-}
-.log-output {
-  flex: 0 0 350px;
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: auto;
+  border-radius: 999px;
+  pointer-events: none;
+  z-index: 0;
+  filter: blur(24px);
+  opacity: 0.9;
 }
 
-.section-header-row {
+body::before {
+  width: 420px;
+  height: 420px;
+  top: -90px;
+  left: -100px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.78) 0%, rgba(161, 197, 255, 0.22) 48%, transparent 72%);
+}
+
+body::after {
+  width: 360px;
+  height: 360px;
+  right: -70px;
+  bottom: -40px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.8) 0%, rgba(255, 196, 161, 0.22) 46%, transparent 70%);
+}
+
+body.auth-page {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 10px;
-  border-bottom: 1px solid #e5e7eb;
-  padding-bottom: 6px;
-}
-.section-header-row h2 {
-  margin: 0;
-  border-bottom: none;
-  padding-bottom: 0;
-}
-.log-output {
-  margin-top: 0.25rem;
-  background-color: #0b1020;
-  color: #a7f3d0;
-  padding: 14px 12px 6px;
-  height: 350px;
-  overflow-y: scroll;
-  overflow-x: auto;
-  border-radius: 8px;
-  border: 1px solid #111827;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  font-family: "Courier New", Courier, monospace;
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-/* 左侧追踪日志：占满剩余高度但不溢出 */
-.tracker-log-output {
-  flex: 1 1 0;
-  height: auto;
-  min-height: 0;
-}
-
-.log-container h3 {
-  margin-top: 12px;
-  margin-bottom: 4px;
-}
-
-.remote-header {
-  margin-top: 6px;
-  margin-bottom: 2px;
-}
-
-.tracking-input-row {
-  margin-top: 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-.tracking-input-row label {
-  font-weight: 600;
-  font-size: 14px;
-}
-.tracking-input-controls {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.tracking-input-controls input {
-  flex: 1;
-  padding: 8px 10px;
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  font-size: 15px;
-}
-.icon-btn {
-  width: 32px;
-  height: 32px;
-  display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid #e5e7eb;
-  background: #f8fafc;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: background 0.2s, box-shadow 0.2s, transform 0.05s;
-}
-.icon-btn svg {
-  width: 16px;
-  height: 16px;
-  fill: #0f172a;
-}
-.icon-btn:hover {
-  background: #eef2f7;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
-  transform: translateY(-1px);
-}
-.icon-btn:active {
-  transform: translateY(0);
-}
-.tracking-input-hint {
-  font-size: 12px;
-  color: #64748b;
 }
 
-.tracking-section {
-  padding-bottom: 10px;
-  margin-bottom: 10px;
-  border-bottom: 1px dashed #e5e7eb;
-}
-.refresh-btn.apply-tracking {
-  padding: 6px 12px;
-  font-size: 14px;
-}
-.controls {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.controls button {
-  padding: 8px 14px;
-  margin-right: 6px;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 15px;
-  font-weight: 600;
-  transition: opacity 0.2s, transform 0.05s, box-shadow 0.2s;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
-}
-.controls button.start {
-  background-color: #22c55e;
-  color: white;
-}
-.controls button.stop {
-  background-color: #ef4444;
-  color: white;
-}
-.controls button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(15, 23, 42, 0.16);
-}
-.controls button:active:not(:disabled) {
-  transform: translateY(0);
-  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.12);
-}
-.controls button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-.status-indicator {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background-color: gray;
-  margin-left: 8px;
-  vertical-align: middle;
-  transition: background-color 0.3s;
-}
-.status-indicator.running {
-  background-color: #22c55e;
-  box-shadow: 0 0 8px rgba(34, 197, 94, 0.7);
-  animation: status-pulse 1.8s ease-in-out infinite;
-}
-.status-indicator.stopped {
-  background-color: #ef4444;
-}
-.status-indicator.keepalive.ok {
-  background-color: #22c55e;
-  box-shadow: 0 0 8px rgba(34, 197, 94, 0.7);
-  animation: keepalive-pulse-green 2.2s ease-in-out infinite;
-}
-.status-indicator.keepalive.pending {
-  background-color: #facc15;
-  box-shadow: 0 0 8px rgba(250, 204, 21, 0.7);
-  animation: keepalive-pulse-yellow 2.2s ease-in-out infinite;
-}
-.status-indicator.keepalive.error {
-  background-color: #ef4444;
-  box-shadow: 0 0 8px rgba(239, 68, 68, 0.7);
-  animation: keepalive-pulse-red 2.2s ease-in-out infinite;
-}
-.status-indicator.keepalive.stopped {
-  background-color: #9ca3af;
-  box-shadow: none;
-}
-.status-group {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-left: 4px;
-}
-.status-label {
-  font-size: 12px;
-  color: #374151;
-  margin-right: 6px;
-}
-
-.keepalive-result {
-  flex: 1;
-  min-width: 0;
-  margin-left: 8px;
-  padding: 6px 10px;
-  background: #111827;
-  color: #e5e7eb;
-  border-radius: 8px;
-  font-size: 11px;
-  line-height: 1.35;
-  white-space: normal;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
+.container {
+  position: relative;
+  z-index: 1;
+  width: min(1360px, 100%);
+  margin: 0 auto;
+  padding: 28px;
+  border-radius: var(--radius-xl);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.4) 0%, rgba(255, 255, 255, 0.26) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: var(--blur-xl);
+  -webkit-backdrop-filter: var(--blur-xl);
   overflow: hidden;
 }
 
-/* --- Mobile layout --- */
-@media (max-width: 768px) {
-  body {
-    margin: 10px;
-    -webkit-text-size-adjust: 100%;
-  }
-  .container {
-    padding: 14px;
-    border-radius: 10px;
-  }
-  .header h1 {
-    font-size: 18px;
-    line-height: 1.25;
-  }
-  .section {
-    padding: 12px;
-  }
-  .flex-container {
-    flex-direction: column;
-    gap: 14px;
-  }
-  .flex-child {
-    width: 100%;
-  }
-  .service-panel {
-    min-height: auto;
-  }
-  .log-output {
-    height: min(280px, 42vh);
-    flex: 0 0 min(280px, 42vh);
-  }
-  .tracker-log-output {
-    height: min(320px, 48vh);
-    flex: 0 0 min(320px, 48vh);
-  }
-  .controls {
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-  .controls button {
-    font-size: 14px;
-    padding: 8px 12px;
-  }
-  .status-group {
-    flex-wrap: wrap;
-  }
-  .remote-refresh-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  .remote-refresh-toggle {
-    justify-content: flex-start;
-    width: 100%;
-  }
-  .remote-refresh-toggle .tab-btn {
-    flex: 1;
-    text-align: center;
-  }
-  .remote-refresh-right {
-    width: 100%;
-  }
-  .remote-refresh-interval {
-    width: 100%;
-    flex-wrap: wrap;
-  }
-  .remote-refresh-interval .time-input {
-    width: 80px;
-  }
-  .remote-health-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  .remote-health-row input {
-    width: 100%;
-  }
-  .remote-panel {
-    padding: 8px;
-  }
-  .tracking-input-controls {
-    flex-wrap: wrap;
-  }
-  .tracking-input-controls input {
-    width: 100%;
-    flex-basis: 100%;
-  }
-  .keepalive-result {
-    margin-left: 0;
-    width: 100%;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
-  }
-  .header {
-    flex-wrap: wrap;
-    gap: 10px;
-  }
-  .page-tabs {
-    width: 100%;
-    justify-content: flex-start;
-    display: flex;
-  }
-  .page-tab {
-    flex: 1;
-    text-align: center;
-    padding: 8px 10px;
-    font-size: 13px;
-  }
-  .logs-tabbar {
-    flex-wrap: wrap;
-  }
-  .tab-bar {
-    flex-wrap: wrap;
-  }
-  .param-table {
-    display: block;
-    overflow-x: auto;
-  }
-  .param-table td {
-    white-space: nowrap;
-  }
+.container::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: calc(var(--radius-xl) - 1px);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.26), transparent 24%),
+    linear-gradient(120deg, rgba(255, 255, 255, 0.14), transparent 38%);
+  pointer-events: none;
 }
 
-@media (max-width: 420px) {
-  body {
-    margin: 8px;
-  }
-  .container {
-    padding: 12px;
-  }
-  .header h1 {
-    font-size: 16px;
-  }
-  .page-tab {
-    font-size: 12px;
-    padding: 7px 8px;
-  }
-}
-
-@keyframes status-pulse {
-  0% {
-    opacity: 0.55;
-    box-shadow: 0 0 4px rgba(34, 197, 94, 0.3);
-  }
-  50% {
-    opacity: 1;
-    box-shadow: 0 0 10px rgba(34, 197, 94, 0.9);
-  }
-  100% {
-    opacity: 0.55;
-    box-shadow: 0 0 4px rgba(34, 197, 94, 0.3);
-  }
-}
-
-@keyframes keepalive-pulse-green {
-  0% {
-    opacity: 0.5;
-    box-shadow: 0 0 4px rgba(34, 197, 94, 0.3);
-  }
-  50% {
-    opacity: 1;
-    box-shadow: 0 0 10px rgba(34, 197, 94, 0.9);
-  }
-  100% {
-    opacity: 0.5;
-    box-shadow: 0 0 4px rgba(34, 197, 94, 0.3);
-  }
-}
-
-@keyframes keepalive-pulse-yellow {
-  0% {
-    opacity: 0.5;
-    box-shadow: 0 0 4px rgba(250, 204, 21, 0.3);
-  }
-  50% {
-    opacity: 1;
-    box-shadow: 0 0 10px rgba(250, 204, 21, 0.9);
-  }
-  100% {
-    opacity: 0.5;
-    box-shadow: 0 0 4px rgba(250, 204, 21, 0.3);
-  }
-}
-
-@keyframes keepalive-pulse-red {
-  0% {
-    opacity: 0.5;
-    box-shadow: 0 0 4px rgba(239, 68, 68, 0.3);
-  }
-  50% {
-    opacity: 1;
-    box-shadow: 0 0 10px rgba(239, 68, 68, 0.9);
-  }
-  100% {
-    opacity: 0.5;
-    box-shadow: 0 0 4px rgba(239, 68, 68, 0.3);
-  }
-}
-.env-form {
+.header {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-}
-.env-form label {
-  display: block;
-  margin-bottom: 5px;
-  font-weight: bold;
-}
-.env-form input[type="text"] {
-  width: calc(100% - 22px);
-  padding: 8px;
-  margin-bottom: 10px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-}
-.env-form button {
-  background-color: #111827;
-  color: white;
-  padding: 10px 20px;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-}
-.env-form input[type="text"]:focus,
-.tracking-input-controls input:focus,
-.param-input:focus,
-.time-input:focus,
-select:focus {
-  outline: none;
-  border-color: #cbd5e1;
-  box-shadow: 0 0 0 3px rgba(203, 213, 225, 0.6);
-}
-.message {
-  margin-top: 10px;
-  padding: 10px;
-  border-radius: 5px;
-}
-.message.success {
-  background-color: #d4edda;
-  color: #155724;
-  border: 1px solid #c3e6cb;
-}
-.message.error {
-  background-color: #f8d7da;
-  color: #721c24;
-  border: 1px solid #f5c6cb;
+  gap: 18px;
+  padding-top: 56px;
+  margin-bottom: 24px;
 }
 
-.bark-params {
-  margin-bottom: 10px;
+.header-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+  max-width: none;
 }
-.param-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 5px 0;
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.42);
+  border: 1px solid rgba(255, 255, 255, 0.52);
+  color: var(--blue-deep);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
-.param-table td {
-  padding: 5px;
-  border: 1px solid #ddd;
+
+.header h1 {
+  margin: 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.2rem, 3.2vw, 3.5rem);
+  letter-spacing: -0.05em;
+  line-height: 0.92;
 }
-.param-name {
-  font-weight: bold;
+
+.page-copy,
+.hero-subtitle {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 14px;
+  line-height: 1.7;
+  max-width: 70ch;
 }
-.param-desc {
-  font-size: 12px;
-  color: #555;
+
+.header .page-copy {
+  max-width: none;
 }
-.param-input {
-  width: 99%;
-  max-width: 100%;
-  padding: 5px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
-.inline-field {
+
+.header-actions {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 5px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
-.time-input {
-  width: 70px;
-  padding: 5px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+.header-session {
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
-/* --- Bark 本地/远程 Tab --- */
-.tab-bar {
-  display: flex;
-  gap: 8px;
-}
-.tab-btn {
-  background: #e9ecef;
-  border: 1px solid #ccc;
-  padding: 6px 10px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-}
-.tab-btn.active {
-  background: #111827;
-  color: #fff;
-  border-color: #111827;
+.header-nav {
+  min-width: 0;
+  width: 100%;
 }
 
 .page-tabs {
   display: inline-flex;
-  justify-content: flex-end;
-  margin: 0;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
-  overflow: hidden;
-  background: #f8fafc;
-}
-.page-tab {
-  padding: 9px 14px;
-  border: none;
-  border-right: 1px solid #e5e7eb;
-  background: transparent;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 600;
-  color: #111827;
-  transition: background 0.2s, border-color 0.2s, color 0.2s;
-  border-radius: 0;
-}
-.page-tabs .page-tab:last-child {
-  border-right: none;
-}
-.page-tab:hover:not(.active) {
-  background: #eef2f7;
-}
-.page-tab.active {
-  background: #111827;
-  color: #fff;
-}
-
-.logs-tabbar {
-  margin-bottom: 10px;
-}
-.remote-panel {
-  background: #fff;
-  border: 1px solid #eee;
-  padding: 10px;
-  border-radius: 4px;
-}
-.remote-header {
-  display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
-
-  h3 {
-    margin: 0;
-  }
-}
-.refresh-btn {
-  padding: 6px 12px;
-  border: none;
-  border-radius: 8px;
-  background: #111827;
-  color: #fff;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 600;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
-  transition: opacity 0.2s, transform 0.05s, box-shadow 0.2s, background 0.2s;
-}
-.refresh-btn:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(15, 23, 42, 0.16);
-  background: #0b1220;
-}
-.refresh-btn:active:not(:disabled) {
-  transform: translateY(0);
-  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.12);
-}
-.refresh-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-.remote-refresh-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 6px 0 10px;
-  border-bottom: 1px dashed #e5e7eb;
-  margin-bottom: 8px;
-}
-.remote-refresh-toggle {
-  display: flex;
   gap: 6px;
+  padding: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.58);
+  backdrop-filter: var(--blur-md);
+  -webkit-backdrop-filter: var(--blur-md);
 }
+
+.page-tab,
+.ghost-btn,
+.refresh-btn,
+.env-save-btn,
+.auth-form button,
+.controls button {
+  min-height: 44px;
+  border: 0;
+  border-radius: 999px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease,
+    color 180ms ease,
+    opacity 180ms ease;
+}
+
+.page-tab {
+  min-width: 96px;
+  padding: 0 18px;
+  background: transparent;
+  color: var(--ink-soft);
+}
+
+.page-tab:hover:not(.active),
+.ghost-btn:hover,
+.refresh-btn:hover:not(:disabled),
+.env-save-btn:hover:not(:disabled),
+.auth-form button:hover {
+  transform: translateY(-1px);
+}
+
+.page-tab.active {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(225, 236, 255, 0.56));
+  color: var(--ink-strong);
+  box-shadow:
+    0 8px 18px rgba(63, 96, 155, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.78);
+}
+
+.logout-form {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: nowrap;
+}
+
+.current-user,
+.panel-user-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.46);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 700;
+  backdrop-filter: var(--blur-md);
+  -webkit-backdrop-filter: var(--blur-md);
+}
+
+.header-session .current-user {
+  max-width: 220px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.panel-user-chip {
+  color: var(--blue-deep);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.5), rgba(214, 230, 255, 0.42));
+}
+
+.ghost-btn,
+.refresh-btn,
+.env-save-btn,
+.auth-form button {
+  padding: 0 18px;
+  color: var(--ink-strong);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(227, 236, 255, 0.46));
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  box-shadow:
+    0 10px 22px rgba(79, 108, 165, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.82);
+}
+
+.env-save-btn,
+.auth-form button {
+  color: #fff;
+  background: linear-gradient(135deg, #5e7ffb 0%, #7d9cff 52%, #78d8ef 100%);
+  box-shadow:
+    0 18px 28px rgba(76, 108, 221, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22);
+}
+
+.controls button.start {
+  padding: 0 18px;
+  color: #0f4530;
+  background: linear-gradient(135deg, rgba(154, 255, 218, 0.95), rgba(93, 217, 170, 0.84));
+  box-shadow: 0 16px 28px rgba(72, 182, 140, 0.24);
+}
+
+.controls button.stop {
+  padding: 0 18px;
+  color: #651629;
+  background: linear-gradient(135deg, rgba(255, 188, 205, 0.96), rgba(243, 105, 137, 0.82));
+  box-shadow: 0 16px 28px rgba(231, 84, 121, 0.22);
+}
+
+.page-tab:disabled,
+.ghost-btn:disabled,
+.refresh-btn:disabled,
+.env-save-btn:disabled,
+.controls button:disabled,
+.auth-form button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+h2,
+h3 {
+  margin: 0;
+  color: var(--ink-strong);
+}
+
+h2 {
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+h3 {
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.section,
+.auth-card,
+.users-sidebar,
+.users-editor,
+.guide-panel {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.46);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.44), rgba(255, 255, 255, 0.24)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(212, 230, 255, 0.14));
+  box-shadow: var(--shadow-md);
+  backdrop-filter: var(--blur-lg);
+  -webkit-backdrop-filter: var(--blur-lg);
+  animation: panel-rise 520ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.section::before,
+.auth-card::before,
+.users-sidebar::before,
+.users-editor::before,
+.guide-panel::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: calc(var(--radius-lg) - 1px);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.34), transparent 22%),
+    radial-gradient(circle at top right, rgba(255, 255, 255, 0.34), transparent 26%);
+  pointer-events: none;
+}
+
+.section {
+  padding: 20px;
+}
+
+.hero-surface {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 18px;
+  padding: 20px;
+  border-radius: calc(var(--radius-lg) - 2px);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.54), rgba(225, 236, 255, 0.22)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.2), transparent);
+  border: 1px solid rgba(255, 255, 255, 0.54);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.72),
+    0 20px 38px rgba(85, 111, 165, 0.12);
+  overflow: hidden;
+}
+
+.hero-surface::before {
+  content: "";
+  position: absolute;
+  inset: auto -10% -30% auto;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(121, 216, 255, 0.24), transparent 62%);
+  filter: blur(12px);
+  pointer-events: none;
+}
+
+.hero-surface.compact {
+  padding: 18px;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.9fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.hero-grid.compact-grid {
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.8fr);
+}
+
+.hero-grid.single-pane {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.portal-hero-grid {
+  grid-template-columns: minmax(0, 1.25fr) minmax(300px, 0.95fr);
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hero-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 2vw, 2.1rem);
+  line-height: 1.02;
+  letter-spacing: -0.04em;
+}
+
+.hero-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.hero-pill,
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.34);
+  color: var(--ink-strong);
+  font-size: 12px;
+  font-weight: 800;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.62);
+}
+
+.status-badge.ok {
+  color: #0d6e47;
+  background: rgba(213, 255, 235, 0.68);
+}
+
+.status-badge.error {
+  color: #8e2038;
+  background: rgba(255, 224, 231, 0.74);
+}
+
+.status-badge.pending {
+  color: #8a5c10;
+  background: rgba(255, 241, 217, 0.76);
+}
+
+.hero-metrics {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.hero-metrics.single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.hero-metrics.summary-strip {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 4px;
+}
+
+.hero-metric,
+.user-insight-card {
+  min-height: 112px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(239, 244, 255, 0.3)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(194, 226, 255, 0.14));
+  border: 1px solid rgba(255, 255, 255, 0.54);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hero-metric strong,
+.user-insight-card strong {
+  color: var(--ink-strong);
+  font-size: 1.25rem;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.metric-url {
+  font-size: 1rem;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.hero-metric-label {
+  display: block;
+  color: var(--ink-soft);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.section-note {
+  position: relative;
+  z-index: 1;
+  margin: 0 0 16px;
+  padding: 14px 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  color: var(--ink-soft);
+  font-size: 13px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.56);
+}
+
+.flex-container {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.flex-child {
+  min-width: 0;
+  display: flex;
+}
+
+.service-panel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 560px;
+}
+
+.section-header-row,
+.editor-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.section-header-row.compact {
+  margin-bottom: 0;
+}
+
+.controls {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.status-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 0 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.34);
+  border: 1px solid rgba(255, 255, 255, 0.44);
+}
+
+.status-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(117, 136, 167, 0.6);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.16);
+}
+
+.status-indicator.running,
+.status-indicator.keepalive.ok {
+  background: var(--green);
+  box-shadow: 0 0 0 5px rgba(37, 178, 111, 0.16), 0 0 20px rgba(37, 178, 111, 0.28);
+}
+
+.status-indicator.stopped,
+.status-indicator.keepalive.error {
+  background: var(--red);
+  box-shadow: 0 0 0 5px rgba(234, 91, 115, 0.16), 0 0 20px rgba(234, 91, 115, 0.26);
+}
+
+.status-indicator.keepalive.pending {
+  background: var(--amber);
+  box-shadow: 0 0 0 5px rgba(255, 185, 95, 0.16), 0 0 20px rgba(255, 185, 95, 0.22);
+}
+
+.status-indicator.keepalive.stopped {
+  background: rgba(146, 158, 184, 0.52);
+  box-shadow: none;
+}
+
+.status-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--ink-soft);
+}
+
+.keepalive-result {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 16px;
+  border-radius: 999px;
+  background: rgba(20, 34, 63, 0.78);
+  color: #eef5ff;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.dashboard-stats {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.stat-card {
+  padding: 16px 18px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.34);
+  border: 1px solid rgba(255, 255, 255, 0.48);
+  box-shadow: var(--shadow-sm);
+}
+
+.stat-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--ink-soft);
+  letter-spacing: 0.02em;
+}
+
+.stat-card strong {
+  font-size: 1.4rem;
+  color: var(--ink-strong);
+}
+
+.log-container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  flex: 1;
+}
+
+.log-output {
+  flex: 1 1 0;
+  min-height: 310px;
+  max-height: 420px;
+  padding: 18px;
+  border-radius: 22px;
+  overflow: auto;
+  background:
+    radial-gradient(circle at top right, rgba(110, 234, 255, 0.08), transparent 24%),
+    linear-gradient(180deg, rgba(12, 22, 42, 0.92), rgba(10, 18, 34, 0.96));
+  border: 1px solid rgba(120, 177, 255, 0.16);
+  color: #c9f8f1;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 18px 36px rgba(11, 20, 39, 0.22);
+  font-family: "SFMono-Regular", "Cascadia Code", "Consolas", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.remote-panel {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.tab-bar,
+.remote-refresh-toggle {
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tab-btn {
+  min-height: 44px;
+  padding: 0 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.48);
+  background: rgba(255, 255, 255, 0.32);
+  color: var(--ink-soft);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 180ms ease, background 180ms ease, color 180ms ease, box-shadow 180ms ease;
+}
+
+.tab-btn.active {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.76), rgba(225, 236, 255, 0.58));
+  color: var(--ink-strong);
+  box-shadow: 0 8px 18px rgba(66, 98, 165, 0.16);
+}
+
+.remote-refresh-row,
+.remote-health-row,
+.portal-actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.portal-actions.dual {
+  justify-content: space-between;
+}
+
+.user-form-grid + .portal-actions {
+  margin-top: 20px;
+}
+
+.users-editor .guide-panel.slim {
+  margin-top: 20px;
+}
+
 .remote-refresh-right {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
   flex: 1;
+  justify-content: flex-end;
 }
+
 .remote-refresh-interval {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.34);
+  border: 1px solid rgba(255, 255, 255, 0.46);
+}
+
+.remote-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: var(--ink);
+}
+
+.remote-label {
+  font-weight: 800;
+  color: var(--ink-strong);
+}
+
+.remote-status.ok {
+  color: var(--green);
+  font-weight: 800;
+}
+
+.remote-status.bad,
+.remote-error {
+  color: #c13a55;
+  font-weight: 800;
+}
+
+.home-focus-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.9fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.home-side-column,
+.portal-side-column {
+  display: grid;
+  gap: 18px;
+}
+
+.users-layout,
+.user-portal-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(290px, 360px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.user-portal-grid {
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+}
+
+.users-sidebar,
+.users-editor,
+.guide-panel {
+  padding: 18px;
+}
+
+.user-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.user-card {
+  width: 100%;
+  padding: 14px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.48);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.44), rgba(229, 238, 255, 0.26));
+  text-align: left;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.user-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 34px rgba(69, 92, 142, 0.16);
+}
+
+.user-card.active {
+  border-color: rgba(94, 127, 251, 0.42);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.58), rgba(210, 226, 255, 0.38));
+  box-shadow: 0 24px 44px rgba(73, 108, 199, 0.18);
+}
+
+.user-card-top {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.user-card-top strong {
+  font-size: 15px;
+  color: var(--ink-strong);
+}
+
+.user-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(99, 126, 255, 0.9), rgba(110, 224, 243, 0.84));
+  color: #fff;
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.user-card-line {
+  color: var(--ink-soft);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.users-create {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(109, 132, 174, 0.18);
+}
+
+.users-create-body {
+  margin-top: 14px;
+}
+
+.users-create-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+.users-create-grid > div,
+.env-field-card {
+  padding: 14px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.56);
+}
+
+.users-create-grid .full {
+  padding: 0;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+}
+
+.users-create-actions {
+  margin-top: 14px;
+}
+
+.tracking-toggle-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.home-status-card,
+.service-summary-card,
+.tracking-history-item {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(239, 244, 255, 0.3)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(194, 226, 255, 0.14));
+  border: 1px solid rgba(255, 255, 255, 0.54);
+  box-shadow: var(--shadow-sm);
+}
+
+.home-status-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.home-status-card strong {
+  color: var(--ink-strong);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.home-actions {
+  margin-top: 20px;
+}
+
+.tracking-history-list,
+.service-summary-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.tracking-history-item {
+  display: flex;
+  flex-direction: column;
   gap: 6px;
+}
+
+.tracking-history-item strong {
+  color: var(--ink-strong);
+  font-size: 15px;
+}
+
+.tracking-history-item span,
+.service-summary-note {
+  color: var(--ink-soft);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.empty-history {
+  margin: 0;
+}
+
+.compact-actions {
+  margin-top: 12px;
+}
+
+.compact-remote {
+  margin-top: 14px;
+}
+
+.user-insight-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.user-form-grid,
+.env-form {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px 18px;
+}
+
+.user-form-grid .full {
+  grid-column: 1 / -1;
+}
+
+.env-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 800;
+  color: var(--ink-soft);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="number"],
+select,
+textarea {
+  width: 100%;
+  min-height: 48px;
+  padding: 12px 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.54);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(245, 248, 255, 0.46));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.7),
+    0 12px 24px rgba(95, 119, 164, 0.08);
+  color: var(--ink-strong);
+  font: inherit;
+}
+
+textarea {
+  min-height: 118px;
+  resize: vertical;
+}
+
+.field-hint {
+  margin: 8px 2px 0;
+  color: var(--ink-soft);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.test-panel {
+  padding: 16px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.46);
+  box-shadow: var(--shadow-sm);
+}
+
+.test-panel-header {
+  margin-bottom: 14px;
+}
+
+.test-panel-header h3 {
+  margin-bottom: 6px;
+}
+
+.test-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px 18px;
+}
+
+.test-grid .full {
+  grid-column: 1 / -1;
+}
+
+input:focus,
+select:focus,
+textarea:focus,
+button:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px rgba(117, 154, 255, 0.22),
+    0 14px 28px rgba(95, 119, 164, 0.12);
+  border-color: rgba(95, 127, 255, 0.58);
+}
+
+input:disabled {
+  color: rgba(34, 53, 84, 0.58);
+  background: rgba(255, 255, 255, 0.4);
+}
+
+input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: var(--blue);
+}
+
+.checkbox-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.time-input {
+  width: 82px;
+}
+
+.inline-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.message {
+  position: relative;
+  z-index: 1;
+  margin-top: 16px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  font-size: 14px;
+  font-weight: 700;
+  border: 1px solid transparent;
+  backdrop-filter: var(--blur-md);
+  -webkit-backdrop-filter: var(--blur-md);
+}
+
+.message.success {
+  color: #0d6240;
+  background: rgba(213, 255, 235, 0.6);
+  border-color: rgba(85, 194, 140, 0.3);
+}
+
+.message.error {
+  color: #8e2038;
+  background: rgba(255, 222, 229, 0.7);
+  border-color: rgba(228, 88, 125, 0.28);
+}
+
+.auth-shell {
+  position: relative;
+  z-index: 1;
+  width: min(1220px, 100%);
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(380px, 0.95fr);
+  gap: 20px;
+}
+
+.auth-shell.auth-single {
+  width: min(460px, 100%);
+  grid-template-columns: 1fr;
+}
+
+.auth-hero {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 28px;
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(255, 255, 255, 0.54);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.46), rgba(255, 255, 255, 0.22)),
+    linear-gradient(140deg, rgba(255, 255, 255, 0.2), rgba(205, 225, 255, 0.14));
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: var(--blur-xl);
+  -webkit-backdrop-filter: var(--blur-xl);
+  overflow: hidden;
+}
+
+.auth-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 10%, rgba(255, 255, 255, 0.42), transparent 22%),
+    radial-gradient(circle at 82% 78%, rgba(121, 216, 255, 0.18), transparent 28%);
+  pointer-events: none;
+}
+
+.auth-hero h1 {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.5rem, 4vw, 4.3rem);
+  line-height: 0.94;
+  letter-spacing: -0.06em;
+  color: var(--ink-strong);
+}
+
+.auth-stack {
+  display: grid;
+  gap: 18px;
+}
+
+.auth-card {
+  padding: 26px;
+}
+
+.auth-card-simple {
+  padding: 28px 24px;
+}
+
+.auth-eyebrow {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.44);
+  color: var(--blue-deep);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.auth-card h1 {
+  position: relative;
+  z-index: 1;
+  margin: 14px 0 8px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 2.5vw, 2.6rem);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+}
+
+.auth-single-title {
+  margin: 16px 0 8px;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 8vw, 2.8rem);
+  line-height: 0.96;
+  letter-spacing: -0.05em;
+}
+
+.auth-subtitle,
+.auth-help {
+  position: relative;
+  z-index: 1;
+  color: var(--ink-soft);
   font-size: 14px;
 }
+
+.auth-form {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 18px;
+}
+
+.card-title {
+  position: relative;
+  z-index: 1;
+  margin: 14px 0 8px;
+  font-family: var(--font-display);
+  font-size: 1.9rem;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.auth-highlights {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.auth-highlight {
+  padding: 14px 16px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.48);
+  box-shadow: var(--shadow-sm);
+}
+
+.highlight-label {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--ink-soft);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.auth-highlight strong {
+  color: var(--ink-strong);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.auth-guide {
+  padding: 18px;
+}
+
+.auth-link-row {
+  position: relative;
+  z-index: 1;
+  margin-top: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: var(--ink-soft);
+  font-size: 13px;
+}
+
+.auth-link-row a {
+  color: var(--blue-deep);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.auth-link-row a:hover {
+  text-decoration: underline;
+}
+
+.auth-help code,
+.guide-list code,
+.guide-step code,
+.field-hint code {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.48);
+  color: var(--ink-strong);
+  font-size: 12px;
+}
+
+.guide-panel h2,
+.guide-panel h3 {
+  margin-bottom: 12px;
+}
+
+.guide-steps {
+  display: grid;
+  gap: 12px;
+}
+
+.guide-step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.46);
+  box-shadow: var(--shadow-sm);
+}
+
+.guide-step-no {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 54px;
+  height: 40px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(94, 127, 251, 0.94), rgba(121, 216, 255, 0.86));
+  color: #fff;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.guide-step strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--ink-strong);
+  font-size: 14px;
+}
+
+.guide-step p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.guide-list {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--ink);
+}
+
+.guide-list li {
+  margin-bottom: 10px;
+}
+
+.logs-tabbar {
+  margin-bottom: 14px;
+}
+
 .refresh-btn.full {
   width: 100%;
 }
+
 .refresh-btn.apply-btn {
-  padding: 6px 10px;
-  font-size: 13px;
-  white-space: nowrap;
+  min-height: 38px;
+  padding: 0 14px;
 }
-.remote-health-config {
-  margin-bottom: 8px;
-  padding-bottom: 8px;
-  border-bottom: 1px dashed #e5e7eb;
+
+.compact-btn {
+  min-height: 36px;
+  padding: 0 14px;
 }
-.remote-health-config label {
-  display: block;
-  font-weight: 600;
-  margin-bottom: 4px;
+
+@keyframes panel-rise {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
-.remote-health-row {
-  display: flex;
-  gap: 8px;
-  align-items: center;
+
+@media (max-width: 1100px) {
+  .flex-container,
+  .auth-shell,
+  .hero-grid,
+  .home-focus-grid,
+  .user-portal-grid,
+  .users-layout,
+  .test-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-metrics,
+  .auth-highlights,
+  .user-insight-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .header-copy {
+    max-width: none;
+  }
 }
-.remote-health-row input {
-  flex: 1;
-  padding: 6px 8px;
-  border: 1px solid #cbd5e1;
-  border-radius: 6px;
-  font-size: 14px;
+
+@media (max-width: 760px) {
+  body {
+    padding: 12px;
+  }
+
+  .container {
+    padding: 14px;
+    border-radius: 22px;
+  }
+
+  .header h1,
+  .auth-card h1,
+  .auth-hero h1 {
+    font-size: clamp(1.8rem, 11vw, 2.6rem);
+  }
+
+  .page-tabs,
+  .remote-refresh-right {
+    width: 100%;
+  }
+
+  .header {
+    gap: 14px;
+    padding-top: 54px;
+  }
+
+  .page-tabs {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 8px;
+    justify-content: stretch;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .page-tabs::-webkit-scrollbar,
+  .tab-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .page-tab {
+    flex: 0 0 auto;
+    min-width: max-content;
+    width: auto;
+    white-space: nowrap;
+  }
+
+  .user-form-grid,
+  .env-form,
+  .dashboard-stats,
+  .hero-metrics,
+  .auth-highlights,
+  .user-insight-grid,
+  .test-grid,
+  .service-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section,
+  .auth-card,
+  .users-sidebar,
+  .users-editor,
+  .guide-panel {
+    padding: 13px;
+    border-radius: 18px;
+  }
+
+  .auth-hero {
+    padding: 18px 14px;
+    border-radius: 20px;
+  }
+
+  .hero-surface {
+    padding: 13px;
+    border-radius: 18px;
+    margin-bottom: 14px;
+  }
+
+  .hero-surface.compact {
+    padding: 12px;
+  }
+
+  .hero-copy {
+    gap: 10px;
+  }
+
+  .hero-title {
+    font-size: 1.25rem;
+    line-height: 1.08;
+  }
+
+  .hero-subtitle,
+  .page-copy {
+    font-size: 13px;
+    line-height: 1.55;
+  }
+
+  .hero-pill-row {
+    gap: 8px;
+  }
+
+  .controls,
+  .remote-refresh-row,
+  .portal-actions,
+  .section-header-row,
+  .editor-header {
+    align-items: stretch;
+  }
+
+  .controls button,
+  .refresh-btn,
+  .env-save-btn,
+  .auth-form button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .header-session .ghost-btn {
+    width: auto;
+  }
+
+  .panel-user-chip,
+  .status-group,
+  .keepalive-result,
+  .checkbox-row,
+  .hero-pill,
+  .status-badge {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .header-session .current-user,
+  .header-session .ghost-btn {
+    width: auto;
+  }
+
+  .header-session .current-user {
+    max-width: 140px;
+  }
+
+  .tab-bar {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .tab-btn {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .current-user,
+  .panel-user-chip,
+  .status-group,
+  .keepalive-result,
+  .checkbox-row,
+  .hero-pill,
+  .status-badge {
+    font-size: 12px;
+  }
+
+  .hero-pill,
+  .status-badge,
+  .current-user,
+  .panel-user-chip,
+  .status-group,
+  .keepalive-result,
+  .checkbox-row {
+    min-height: 36px;
+    padding: 0 12px;
+    border-radius: 16px;
+  }
+
+  .hero-metrics,
+  .dashboard-stats,
+  .user-insight-grid {
+    gap: 8px;
+  }
+
+  .hero-metric,
+  .user-insight-card,
+  .stat-card,
+  .env-field-card,
+  .users-create-grid > div:not(.full),
+  .user-card,
+  .test-panel,
+  .remote-line,
+  .guide-step,
+  .section-note,
+  .tracking-history-item,
+  .service-summary-card,
+  .home-status-card {
+    padding: 11px 12px;
+    border-radius: 16px;
+  }
+
+  .hero-metric,
+  .user-insight-card {
+    min-height: 84px;
+    gap: 8px;
+  }
+
+  .hero-metric strong,
+  .user-insight-card strong,
+  .stat-card strong {
+    font-size: 1.05rem;
+    line-height: 1.2;
+  }
+
+  .hero-metric-label,
+  .stat-label,
+  .user-card-line,
+  .field-hint,
+  .section-note {
+    font-size: 11px;
+  }
+
+  .user-card-top {
+    margin-bottom: 6px;
+  }
+
+  .user-card-top strong {
+    font-size: 14px;
+  }
+
+  .user-badge {
+    min-height: 24px;
+    padding: 0 8px;
+    font-size: 10px;
+  }
+
+  .users-create {
+    margin-top: 10px;
+    padding-top: 10px;
+  }
+
+  .users-create-actions {
+    margin-top: 10px;
+  }
+
+  .users-create-body,
+  .user-form-grid + .portal-actions,
+  .users-editor .guide-panel.slim {
+    margin-top: 14px;
+  }
+
+  .home-focus-grid,
+  .home-side-column,
+  .portal-side-column,
+  .tracking-history-list {
+    gap: 14px;
+  }
+
+  .tracking-toggle-row {
+    flex-direction: column;
+  }
+
+  .test-panel-header {
+    margin-bottom: 10px;
+  }
+
+  .log-container {
+    gap: 8px;
+  }
+
+  .log-output {
+    min-height: 220px;
+    max-height: 320px;
+    padding: 14px;
+    border-radius: 18px;
+  }
+
+  .guide-step {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-link-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
-.remote-health-hint {
-  font-size: 12px;
-  color: #64748b;
-  margin-top: 4px;
-}
-.remote-line {
-  margin: 4px 0;
-}
-.remote-label {
-  font-weight: bold;
-  margin-right: 6px;
-}
-.remote-status.ok {
-  color: #28a745;
-  font-weight: bold;
-}
-.remote-status.bad {
-  color: #dc3545;
-  font-weight: bold;
-}
-.remote-error {
-  color: #dc3545;
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,0 +1,674 @@
+import os
+import re
+import sqlite3
+import time
+from urllib.parse import urlparse
+
+from dotenv import dotenv_values
+from werkzeug.security import check_password_hash, generate_password_hash
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+DATA_DIR = os.path.join(BASE_DIR, "data")
+DB_PATH = os.path.join(DATA_DIR, "app.db")
+
+PROFILE_DEFAULTS = {
+    "tracking_number": "",
+    "check_interval": 300,
+    "bark_keys": "",
+    "bark_query_params": "?sound=minuet&level=timeSensitive",
+    "bark_url_enabled": 1,
+}
+
+
+def _ts() -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _connect():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH, timeout=30)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def _has_table(conn, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _load_env_value(env_values, key: str, default: str = "") -> str:
+    value = env_values.get(key)
+    if value is not None and str(value).strip() != "":
+        return str(value).strip().strip("'").strip('"')
+    return os.getenv(key, default).strip()
+
+
+def _normalize_check_interval(value) -> int:
+    try:
+        parsed = int(value)
+        return parsed if parsed > 0 else 300
+    except Exception:
+        return 300
+
+
+def _normalize_bool(value, default: int = 0) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return 1 if value else 0
+    return 1 if str(value).strip().lower() in {"1", "true", "yes", "on"} else 0
+
+
+def _normalize_role(value: str) -> str:
+    return "admin" if str(value).strip().lower() == "admin" else "user"
+
+
+def _normalize_username(value: str) -> str:
+    username = str(value or "").strip().lower()
+    if not username:
+        raise ValueError("用户名不能为空。")
+    if not re.fullmatch(r"[a-z0-9][a-z0-9_.-]{2,31}", username):
+        raise ValueError("用户名只能包含小写字母、数字、点、下划线和短横线，长度 3-32。")
+    return username
+
+
+def _normalize_display_name(value: str, fallback: str = "") -> str:
+    display_name = str(value or "").strip()
+    return display_name or fallback or "未命名用户"
+
+
+def _normalize_tracking_number(value: str) -> str:
+    tracking_number = re.sub(r"\s+", "", str(value or "").strip())
+    return tracking_number.upper()
+
+
+def _mask_secret(value: str) -> str:
+    value = (value or "").strip()
+    if len(value) <= 8:
+        return value
+    return f"{value[:4]}...{value[-4:]}"
+
+
+def _extract_bark_key(raw_value: str) -> str:
+    token = str(raw_value or "").strip()
+    if not token:
+        return ""
+    if "://" not in token:
+        return token
+
+    parsed = urlparse(token)
+    parts = [part for part in parsed.path.split("/") if part]
+    return parts[0].strip() if parts else ""
+
+
+def normalize_bark_keys(value) -> str:
+    if isinstance(value, (list, tuple, set)):
+        raw_items = [str(item or "").strip() for item in value]
+    else:
+        raw_items = re.split(r"[\n,;]+", str(value or ""))
+
+    keys = []
+    seen = set()
+    for item in raw_items:
+        key = _extract_bark_key(item)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        keys.append(key)
+    return "\n".join(keys)
+
+
+def parse_bark_keys(value) -> list[str]:
+    normalized = normalize_bark_keys(value)
+    return [item for item in normalized.splitlines() if item.strip()]
+
+
+def _mask_keys(value: str) -> str:
+    keys = parse_bark_keys(value)
+    if not keys:
+        return ""
+    return ", ".join(_mask_secret(key) for key in keys)
+
+
+def _row_to_account(row, *, include_secret: bool = False):
+    if row is None:
+        return None
+    account = dict(row)
+    account["name"] = account.get("display_name", "")
+    account["check_interval"] = _normalize_check_interval(account.get("check_interval"))
+    account["bark_url_enabled"] = bool(account.get("bark_url_enabled"))
+    account["login_enabled"] = bool(account.get("login_enabled"))
+    account["tracking_enabled"] = bool(account.get("tracking_enabled"))
+    account["is_admin"] = account.get("role") == "admin"
+    account["bark_keys"] = normalize_bark_keys(account.get("bark_keys", ""))
+    account["bark_key"] = account["bark_keys"]
+    account["bark_keys_masked"] = _mask_keys(account["bark_keys"])
+    account["bark_key_masked"] = account["bark_keys_masked"]
+    account["has_password"] = bool(account.get("password_hash"))
+    if not include_secret:
+        account.pop("password_hash", None)
+    return account
+
+
+def load_system_env(dotenv_path: str, keys) -> dict:
+    env_values = dotenv_values(dotenv_path)
+    return {key: _load_env_value(env_values, key, "") for key in keys}
+
+
+def _ensure_accounts_schema(conn):
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS accounts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT NOT NULL UNIQUE,
+            display_name TEXT NOT NULL DEFAULT '',
+            password_hash TEXT NOT NULL DEFAULT '',
+            role TEXT NOT NULL DEFAULT 'user',
+            note TEXT NOT NULL DEFAULT '',
+            tracking_number TEXT NOT NULL DEFAULT '',
+            check_interval INTEGER NOT NULL DEFAULT 300,
+            bark_keys TEXT NOT NULL DEFAULT '',
+            bark_query_params TEXT NOT NULL DEFAULT '?sound=minuet&level=timeSensitive',
+            bark_url_enabled INTEGER NOT NULL DEFAULT 1,
+            login_enabled INTEGER NOT NULL DEFAULT 1,
+            tracking_enabled INTEGER NOT NULL DEFAULT 1,
+            last_tracking_info TEXT NOT NULL DEFAULT '',
+            last_checked_at TEXT NOT NULL DEFAULT '',
+            last_error TEXT NOT NULL DEFAULT '',
+            last_push_at TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _ensure_tracking_history_schema(conn):
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tracking_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id INTEGER NOT NULL,
+            tracking_number TEXT NOT NULL,
+            first_seen_at TEXT NOT NULL,
+            last_seen_at TEXT NOT NULL,
+            seen_count INTEGER NOT NULL DEFAULT 1,
+            UNIQUE(account_id, tracking_number),
+            FOREIGN KEY(account_id) REFERENCES accounts(id) ON DELETE CASCADE
+        )
+        """
+    )
+
+
+def _record_tracking_number(conn, account_id: int, tracking_number: str):
+    normalized = _normalize_tracking_number(tracking_number)
+    if not normalized:
+        return
+
+    now = _ts()
+    existing = conn.execute(
+        """
+        SELECT id, seen_count FROM tracking_history
+        WHERE account_id = ? AND tracking_number = ?
+        """,
+        (account_id, normalized),
+    ).fetchone()
+    if existing:
+        conn.execute(
+            """
+            UPDATE tracking_history
+            SET last_seen_at = ?, seen_count = ?
+            WHERE id = ?
+            """,
+            (now, int(existing["seen_count"] or 0) + 1, existing["id"]),
+        )
+        return
+
+    conn.execute(
+        """
+        INSERT INTO tracking_history (
+            account_id, tracking_number, first_seen_at, last_seen_at, seen_count
+        ) VALUES (?, ?, ?, ?, 1)
+        """,
+        (account_id, normalized, now, now),
+    )
+
+
+def _backfill_tracking_history(conn):
+    rows = conn.execute(
+        """
+        SELECT id, tracking_number
+        FROM accounts
+        WHERE TRIM(tracking_number) != ''
+        """
+    ).fetchall()
+    for row in rows:
+        normalized = _normalize_tracking_number(row["tracking_number"])
+        if not normalized:
+            continue
+        exists = conn.execute(
+            """
+            SELECT 1
+            FROM tracking_history
+            WHERE account_id = ? AND tracking_number = ?
+            """,
+            (int(row["id"]), normalized),
+        ).fetchone()
+        if exists is None:
+            _record_tracking_number(conn, int(row["id"]), normalized)
+
+
+def _history_row_to_item(row):
+    return {
+        "tracking_number": row["tracking_number"],
+        "first_seen_at": row["first_seen_at"],
+        "last_seen_at": row["last_seen_at"],
+        "seen_count": int(row["seen_count"] or 0),
+    }
+
+
+def _attach_tracking_history(conn, accounts: list[dict]):
+    if not accounts:
+        return accounts
+
+    account_ids = [int(account["id"]) for account in accounts]
+    placeholders = ", ".join("?" for _ in account_ids)
+    rows = conn.execute(
+        f"""
+        SELECT account_id, tracking_number, first_seen_at, last_seen_at, seen_count
+        FROM tracking_history
+        WHERE account_id IN ({placeholders})
+        ORDER BY last_seen_at DESC, id DESC
+        """,
+        account_ids,
+    ).fetchall()
+
+    history_map = {account_id: [] for account_id in account_ids}
+    for row in rows:
+        history_map.setdefault(int(row["account_id"]), []).append(_history_row_to_item(row))
+
+    for account in accounts:
+        history = history_map.get(int(account["id"]), [])
+        account["tracking_history"] = history
+        account["tracking_history_count"] = len(history)
+        account["tracking_history_preview"] = history[:8]
+    return accounts
+
+
+def _insert_account(conn, data: dict):
+    tracking_number = _normalize_tracking_number(data.get("tracking_number", ""))
+    cursor = conn.execute(
+        """
+        INSERT INTO accounts (
+            username, display_name, password_hash, role, note,
+            tracking_number, check_interval, bark_keys, bark_query_params,
+            bark_url_enabled, login_enabled, tracking_enabled,
+            last_tracking_info, last_checked_at, last_error, last_push_at,
+            created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            data["username"],
+            data["display_name"],
+            data.get("password_hash", ""),
+            data.get("role", "user"),
+            data.get("note", ""),
+            tracking_number,
+            _normalize_check_interval(data.get("check_interval", 300)),
+            normalize_bark_keys(data.get("bark_keys", "")),
+            str(data.get("bark_query_params", PROFILE_DEFAULTS["bark_query_params"])).strip()
+            or PROFILE_DEFAULTS["bark_query_params"],
+            _normalize_bool(data.get("bark_url_enabled", 1), default=1),
+            _normalize_bool(data.get("login_enabled", 1), default=1),
+            _normalize_bool(data.get("tracking_enabled", 1), default=1),
+            str(data.get("last_tracking_info", "") or ""),
+            str(data.get("last_checked_at", "") or ""),
+            str(data.get("last_error", "") or ""),
+            str(data.get("last_push_at", "") or ""),
+            data.get("created_at", _ts()),
+            data.get("updated_at", _ts()),
+        ),
+    )
+    account_id = cursor.lastrowid
+    if account_id:
+        _record_tracking_number(conn, int(account_id), tracking_number)
+    return account_id
+
+
+def _migrate_legacy_profiles(conn, dotenv_path: str):
+    now = _ts()
+    if _has_table(conn, "user_profiles"):
+        rows = conn.execute("SELECT * FROM user_profiles ORDER BY id").fetchall()
+        for row in rows:
+            note = str(row["note"] or "").strip()
+            legacy_note = "从旧版 user_profiles 迁移"
+            merged_note = f"{legacy_note}；{note}" if note else legacy_note
+            _insert_account(
+                conn,
+                {
+                    "username": f"legacy-user-{row['id']}",
+                    "display_name": str(row["name"] or f"迁移用户 {row['id']}"),
+                    "password_hash": "",
+                    "role": "user",
+                    "note": merged_note,
+                    "tracking_number": str(row["tracking_number"] or ""),
+                    "check_interval": row["check_interval"],
+                    "bark_keys": str(row["bark_key"] or ""),
+                    "bark_query_params": str(row["bark_query_params"] or PROFILE_DEFAULTS["bark_query_params"]),
+                    "bark_url_enabled": row["bark_url_enabled"],
+                    "login_enabled": 0,
+                    "tracking_enabled": 1,
+                    "created_at": str(row["created_at"] or now),
+                    "updated_at": str(row["updated_at"] or now),
+                },
+            )
+        return
+
+    env_values = dotenv_values(dotenv_path)
+    _insert_account(
+        conn,
+        {
+            "username": "legacy-default",
+            "display_name": "默认用户",
+            "password_hash": "",
+            "role": "user",
+            "note": "从 .env 初始化",
+            "tracking_number": _load_env_value(env_values, "TRACKING_NUMBER", ""),
+            "check_interval": _normalize_check_interval(_load_env_value(env_values, "CHECK_INTERVAL", "300")),
+            "bark_keys": _load_env_value(env_values, "BARK_KEY", ""),
+            "bark_query_params": _load_env_value(
+                env_values,
+                "BARK_QUERY_PARAMS",
+                PROFILE_DEFAULTS["bark_query_params"],
+            ),
+            "bark_url_enabled": _normalize_bool(_load_env_value(env_values, "BARK_URL_ENABLED", "1"), default=1),
+            "login_enabled": 0,
+            "tracking_enabled": 1,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+
+
+def _sync_admin_account(conn, admin_username: str, admin_password_hash: str):
+    if not admin_password_hash.strip():
+        return
+
+    username = _normalize_username(admin_username or "admin")
+    row = conn.execute("SELECT * FROM accounts WHERE username = ?", (username,)).fetchone()
+    now = _ts()
+    if row is None:
+        _insert_account(
+            conn,
+            {
+                "username": username,
+                "display_name": "管理员",
+                "password_hash": admin_password_hash.strip(),
+                "role": "admin",
+                "note": "从 .env 管理员配置引导",
+                "tracking_number": "",
+                "check_interval": 300,
+                "bark_keys": "",
+                "bark_query_params": PROFILE_DEFAULTS["bark_query_params"],
+                "bark_url_enabled": 1,
+                "login_enabled": 1,
+                "tracking_enabled": 0,
+                "created_at": now,
+                "updated_at": now,
+            },
+        )
+        return
+
+    conn.execute(
+        """
+        UPDATE accounts
+        SET password_hash = ?, role = 'admin', login_enabled = 1, updated_at = ?
+        WHERE username = ?
+        """,
+        (admin_password_hash.strip(), now, username),
+    )
+
+
+def ensure_storage(dotenv_path: str):
+    admin_username = os.getenv("ADMIN_USERNAME", "admin").strip() or "admin"
+    admin_password_hash = os.getenv("ADMIN_PASSWORD_HASH", "").strip()
+
+    with _connect() as conn:
+        _ensure_accounts_schema(conn)
+        _ensure_tracking_history_schema(conn)
+        count = conn.execute("SELECT COUNT(*) FROM accounts").fetchone()[0]
+        if count == 0:
+            _migrate_legacy_profiles(conn, dotenv_path)
+        _sync_admin_account(conn, admin_username, admin_password_hash)
+        _backfill_tracking_history(conn)
+        conn.commit()
+
+
+def account_to_profile_env(account) -> dict:
+    if not account:
+        return {
+            "TRACKING_NUMBER": "",
+            "CHECK_INTERVAL": "300",
+            "BARK_KEY": "",
+            "BARK_QUERY_PARAMS": PROFILE_DEFAULTS["bark_query_params"],
+            "BARK_URL_ENABLED": "1",
+        }
+    return {
+        "TRACKING_NUMBER": str(account.get("tracking_number", "") or ""),
+        "CHECK_INTERVAL": str(_normalize_check_interval(account.get("check_interval"))),
+        "BARK_KEY": normalize_bark_keys(account.get("bark_keys", "")),
+        "BARK_QUERY_PARAMS": str(account.get("bark_query_params", "") or PROFILE_DEFAULTS["bark_query_params"]),
+        "BARK_URL_ENABLED": "1" if account.get("bark_url_enabled") else "0",
+    }
+
+
+def list_accounts(include_disabled: bool = True):
+    query = "SELECT * FROM accounts"
+    params = []
+    if not include_disabled:
+        query += " WHERE login_enabled = 1 OR tracking_enabled = 1"
+    query += " ORDER BY CASE role WHEN 'admin' THEN 0 ELSE 1 END, id"
+    with _connect() as conn:
+        rows = conn.execute(query, params).fetchall()
+        accounts = [_row_to_account(row) for row in rows]
+        return _attach_tracking_history(conn, accounts)
+
+
+def list_tracked_accounts():
+    with _connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT * FROM accounts
+            WHERE tracking_enabled = 1
+            ORDER BY id
+            """
+        ).fetchall()
+        accounts = [_row_to_account(row) for row in rows]
+        return _attach_tracking_history(conn, accounts)
+
+
+def get_account(account_id: int):
+    with _connect() as conn:
+        row = conn.execute("SELECT * FROM accounts WHERE id = ?", (account_id,)).fetchone()
+        account = _row_to_account(row)
+        if not account:
+            return None
+        return _attach_tracking_history(conn, [account])[0]
+
+
+def get_account_by_username(username: str, *, include_secret: bool = False):
+    if not str(username or "").strip():
+        return None
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM accounts WHERE username = ?",
+            (str(username).strip().lower(),),
+        ).fetchone()
+        account = _row_to_account(row, include_secret=include_secret)
+        if not account:
+            return None
+        return _attach_tracking_history(conn, [account])[0]
+
+
+def verify_account_password(account, password: str) -> bool:
+    if not account or not account.get("password_hash") or not account.get("login_enabled"):
+        return False
+    try:
+        return check_password_hash(account["password_hash"], password)
+    except Exception:
+        return False
+
+
+def _create_account(conn, data: dict, *, self_register: bool = False):
+    username = _normalize_username(data.get("username", ""))
+    display_name = _normalize_display_name(data.get("display_name") or data.get("name"), fallback=username)
+    role = "user" if self_register else _normalize_role(data.get("role", "user"))
+    password = str(data.get("password", "") or data.get("new_password", "")).strip()
+    login_enabled = 1 if self_register else _normalize_bool(data.get("login_enabled", 1), default=1)
+    tracking_enabled = 1 if self_register else _normalize_bool(data.get("tracking_enabled", 1), default=1)
+
+    if login_enabled and not password:
+        raise ValueError("请提供登录密码。")
+    password_hash = generate_password_hash(password) if password else ""
+    now = _ts()
+
+    try:
+        account_id = _insert_account(
+            conn,
+            {
+                "username": username,
+                "display_name": display_name,
+                "password_hash": password_hash,
+                "role": role,
+                "note": str(data.get("note", "")).strip(),
+                "tracking_number": str(data.get("tracking_number", "")).strip(),
+                "check_interval": data.get("check_interval", PROFILE_DEFAULTS["check_interval"]),
+                "bark_keys": data.get("bark_keys") or data.get("bark_key", ""),
+                "bark_query_params": data.get("bark_query_params", PROFILE_DEFAULTS["bark_query_params"]),
+                "bark_url_enabled": data.get("bark_url_enabled", 1),
+                "login_enabled": login_enabled,
+                "tracking_enabled": tracking_enabled,
+                "created_at": now,
+                "updated_at": now,
+            },
+        )
+    except sqlite3.IntegrityError as exc:
+        raise ValueError("用户名已存在。") from exc
+    return {"id": account_id}
+
+
+def create_account(data: dict):
+    with _connect() as conn:
+        account = _create_account(conn, data, self_register=False)
+        conn.commit()
+        return get_account(account["id"])
+
+
+def register_user(data: dict):
+    with _connect() as conn:
+        account = _create_account(conn, data, self_register=True)
+        conn.commit()
+        return get_account(account["id"])
+
+
+def update_account(account_id: int, data: dict, *, actor_role: str = "admin", actor_id: int | None = None):
+    with _connect() as conn:
+        row = conn.execute("SELECT * FROM accounts WHERE id = ?", (account_id,)).fetchone()
+        if row is None:
+            raise ValueError("用户不存在。")
+
+        current = dict(row)
+        is_self = actor_id == account_id
+        if actor_role != "admin" and not is_self:
+            raise ValueError("无权修改其他用户。")
+
+        next_username = current["username"]
+        next_role = current["role"]
+        next_login_enabled = current["login_enabled"]
+        next_tracking_enabled = current["tracking_enabled"]
+        if actor_role == "admin":
+            if "username" in data:
+                next_username = _normalize_username(data["username"])
+            next_role = _normalize_role(data.get("role", current["role"]))
+            next_login_enabled = _normalize_bool(data.get("login_enabled", current["login_enabled"]), default=current["login_enabled"])
+            next_tracking_enabled = _normalize_bool(data.get("tracking_enabled", current["tracking_enabled"]), default=current["tracking_enabled"])
+
+        display_name = _normalize_display_name(
+            data.get("display_name") or data.get("name"),
+            fallback=current["display_name"],
+        )
+        password = str(data.get("password", "") or data.get("new_password", "")).strip()
+        password_hash = current["password_hash"]
+        if password:
+            password_hash = generate_password_hash(password)
+
+        if next_login_enabled and not password_hash:
+            raise ValueError("已启用登录的用户必须设置密码。")
+
+        if current["role"] == "admin" and actor_role != "admin":
+            raise ValueError("普通用户不能修改管理员账号。")
+
+        try:
+            tracking_number = _normalize_tracking_number(data.get("tracking_number", current["tracking_number"]))
+            previous_tracking_number = _normalize_tracking_number(current["tracking_number"])
+            conn.execute(
+                """
+                UPDATE accounts
+                SET username = ?, display_name = ?, password_hash = ?, role = ?, note = ?,
+                    tracking_number = ?, check_interval = ?, bark_keys = ?, bark_query_params = ?,
+                    bark_url_enabled = ?, login_enabled = ?, tracking_enabled = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    next_username,
+                    display_name,
+                    password_hash,
+                    next_role,
+                    str(data.get("note", current["note"])).strip(),
+                    tracking_number,
+                    _normalize_check_interval(data.get("check_interval", current["check_interval"])),
+                    normalize_bark_keys(data.get("bark_keys") or data.get("bark_key", current["bark_keys"])),
+                    str(data.get("bark_query_params", current["bark_query_params"])).strip()
+                    or PROFILE_DEFAULTS["bark_query_params"],
+                    _normalize_bool(data.get("bark_url_enabled", current["bark_url_enabled"]), default=current["bark_url_enabled"]),
+                    next_login_enabled,
+                    next_tracking_enabled,
+                    _ts(),
+                    account_id,
+                ),
+            )
+            if tracking_number and tracking_number != previous_tracking_number:
+                _record_tracking_number(conn, account_id, tracking_number)
+        except sqlite3.IntegrityError as exc:
+            raise ValueError("用户名已存在。") from exc
+
+        conn.commit()
+    return get_account(account_id)
+
+
+def update_tracking_state(account_id: int, *, latest_info: str | None = None, error: str | None = None, pushed: bool = False):
+    with _connect() as conn:
+        row = conn.execute("SELECT * FROM accounts WHERE id = ?", (account_id,)).fetchone()
+        if row is None:
+            return None
+
+        current = dict(row)
+        checked_at = _ts()
+        next_info = current["last_tracking_info"] if latest_info is None else str(latest_info)
+        next_error = current["last_error"] if error is None else str(error)
+        next_push_at = checked_at if pushed else current["last_push_at"]
+        conn.execute(
+            """
+            UPDATE accounts
+            SET last_tracking_info = ?, last_checked_at = ?, last_error = ?, last_push_at = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            (next_info, checked_at, next_error, next_push_at, checked_at, account_id),
+        )
+        conn.commit()
+    return get_account(account_id)

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,189 +3,192 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>快递追踪器与通知服务控制台</title>
+    <title>快递追踪器后台</title>
     <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.min.js"></script>
     <link rel="stylesheet" href="/static/style.css" />
   </head>
-  <body>
+  <body class="dashboard-page">
     <div id="app" class="container">
       <div class="header">
-        <h1>[[ title ]]</h1>
-        <div class="page-tabs">
+        <div class="header-copy">
+          <div class="eyebrow">Admin Control Room</div>
+          <h1>[[ title ]]</h1>
+          <p class="page-copy">本地 Bark、自建公网入口、多用户追踪和日志都集中在这块管理面板里。</p>
+        </div>
+        <form method="post" action="/logout" class="logout-form header-session">
+          <span class="current-user">{{ viewer_state.display_name }} · {{ viewer_state.username }}</span>
+          <button type="submit" class="ghost-btn">退出登录</button>
+        </form>
+        <div class="page-tabs header-nav">
           <button type="button" :class="['page-tab', { active: page === 'home' }]" @click="page = 'home'">首页</button>
-          <button type="button" :class="['page-tab', { active: page === 'env' }]" @click="page = 'env'">环境变量</button>
+          <button type="button" :class="['page-tab', { active: page === 'env' }]" @click="page = 'env'">系统设置</button>
+          <button type="button" :class="['page-tab', { active: page === 'users' }]" @click="page = 'users'">用户管理</button>
           <button type="button" :class="['page-tab', { active: page === 'logs' }]" @click="page = 'logs'">日志</button>
         </div>
       </div>
 
       <div class="section" v-if="page === 'home'">
-        <div class="flex-container">
-          <div class="flex-child">
-            <div class="section service-panel">
-              <div class="section-header-row">
-                <h2>快递追踪脚本</h2>
+        <div class="hero-surface">
+          <div class="hero-grid compact-grid">
+            <div class="hero-copy">
+              <div class="eyebrow">Tracking Focus</div>
+              <h2 class="hero-title">首页直接切换账号、填写单号并管理追踪节奏</h2>
+              <p class="hero-subtitle">
+                这里优先处理追踪本身：选账号、填日本邮政单号、决定是否启用追踪，同时把历史单号档案留在同一页。服务日志单独放到日志页。
+              </p>
+              <div class="hero-pill-row">
+                <span class="hero-pill">当前账号 [[ selectedUser ? (selectedUser.display_name + ' · ' + selectedUser.username) : '未选择账号' ]]</span>
+                <span class="hero-pill">当前单号 [[ selectedUser && selectedUser.tracking_number ? selectedUser.tracking_number : '未填写' ]]</span>
+                <span :class="['status-badge', selectedUserTrackingState.tone]">
+                  [[ selectedUserTrackingState.label ]]
+                </span>
               </div>
-              <div class="controls">
-                <button @click="startScript" :disabled="script.running" class="start">启动脚本</button>
-                <button @click="stopScript" :disabled="!script.running" class="stop">停止脚本</button>
-                <div class="status-group">
-                  <span :class="['status-indicator', { running: script.running, stopped: !script.running }]" title="追踪脚本状态"></span>
-                  <span class="status-label">脚本</span>
-                  <span
-                    :class="['status-indicator', 'keepalive', {
-                      running: keepalive.running,
-                      stopped: !keepalive.running,
-                      ok: keepalive.running
-                        && keepalive.last_at
-                        && keepalive.last_error == null
-                        && keepalive.last_code >= 200 && keepalive.last_code < 400
-                        && keepalive.state !== 'pinging',
-                      error: keepalive.running
-                        && keepalive.last_at
-                        && (keepalive.last_error != null || keepalive.last_code < 200 || keepalive.last_code >= 400)
-                        && keepalive.state !== 'pinging',
-                      pending: keepalive.running
-                        && (keepalive.state === 'pinging' || !keepalive.last_at)
-                    }]"
-                  ></span>
-                  <span class="status-label">保活</span>
-                </div>
-                <div class="keepalive-result" v-if="keepalive.configured">
-                  <template v-if="!keepalive.running">
-                    保活:停用 · [[ keepalive.url ]]
-                  </template>
-                  <template v-else>
-                    <span v-if="keepalive.state === 'pinging'">保活:ping中…</span>
-                    <span v-else>保活:启动中…</span>
-                  </template>
-                  <template v-else-if="keepalive.last_error == null && keepalive.last_code >= 200 && keepalive.last_code < 400">
-                    保活:OK · [[ keepalive.last_at ]] · [[ keepalive.last_code ]]
-                  </template>
-                  <template v-else>
-                    保活:ERR · [[ keepalive.last_at ]] · [[ keepalive.last_error || keepalive.last_code ]]
-                  </template>
-                </div>
-                <div class="keepalive-result" v-else>
-                  保活:关闭（未配 PUBLIC_URL）
-                </div>
+            </div>
+
+            <div class="hero-metrics">
+              <div class="hero-metric">
+                <span class="hero-metric-label">历史单号</span>
+                <strong>[[ selectedUserHistoryCount ]]</strong>
               </div>
-              <div class="log-container">
-                <h3>追踪脚本实时日志</h3>
-                <div class="log-output tracker-log-output" ref="trackerLogOutput">
-                  <div v-for="(line, index) in script.logs" :key="index" v-html="line"></div>
-                </div>
+              <div class="hero-metric">
+                <span class="hero-metric-label">启用追踪</span>
+                <strong>[[ trackedUsersCount ]]</strong>
+              </div>
+              <div class="hero-metric">
+                <span class="hero-metric-label">Bark 设备</span>
+                <strong>[[ selectedUserDeviceCount || 0 ]]</strong>
+              </div>
+              <div class="hero-metric">
+                <span class="hero-metric-label">累计档案</span>
+                <strong>[[ trackedNumbersCount ]]</strong>
               </div>
             </div>
           </div>
+        </div>
 
-          <div class="flex-child">
-            <div class="section service-panel">
+        <div class="section-note">首页只放追踪本身和必要的服务控制。账号权限、密码、Bark Keys 和详细日志分别留在“用户管理”和“日志”页。</div>
+
+        <div class="home-focus-grid">
+          <div class="users-editor tracking-center-panel">
+            <div class="editor-header">
+              <h2>追踪中心</h2>
+              <div :class="['status-badge', selectedUserTrackingState.tone]">[[ selectedUserTrackingState.label ]]</div>
+            </div>
+
+            <div class="user-form-grid home-tracking-grid">
+              <div class="full">
+                <label for="homeSelectedUser">当前账号</label>
+                <select id="homeSelectedUser" v-model.number="selectedUserId" class="param-input">
+                  <option v-for="user in users" :key="user.id" :value="user.id">
+                    [[ user.display_name ]] · [[ user.username ]]
+                  </option>
+                </select>
+              </div>
+              <div class="full">
+                <label for="homeTrackingNumber">日本邮政单号</label>
+                <input id="homeTrackingNumber" type="text" v-model="userForm.tracking_number" />
+                <p class="field-hint">单号入口放在首页。保存后会写入该账号，并进入这个账号的单号档案。</p>
+              </div>
+              <div>
+                <label for="homeCheckInterval">查询间隔（秒）</label>
+                <input id="homeCheckInterval" type="number" min="30" v-model.number="userForm.check_interval" />
+              </div>
+              <div class="home-status-card">
+                <span class="hero-metric-label">最近物流结果</span>
+                <strong>[[ selectedUserLatestStatus ]]</strong>
+              </div>
+              <div class="full tracking-toggle-row">
+                <label class="checkbox-row"><input type="checkbox" v-model="userForm.tracking_enabled" /> 启用追踪</label>
+                <label class="checkbox-row"><input type="checkbox" v-model="userForm.bark_url_enabled" /> 推送附带追踪链接</label>
+              </div>
+            </div>
+
+            <div class="portal-actions dual home-actions">
+              <button type="button" class="env-save-btn" @click="saveUser" :disabled="!selectedUserId || !userForm.username.trim()">保存追踪设置</button>
+              <button type="button" class="ghost-btn" @click="page = 'users'">打开完整账号设置</button>
+            </div>
+            <div v-if="userMessage.text" :class="['message', userMessage.type]">[[ userMessage.text ]]</div>
+          </div>
+
+          <div class="home-side-column">
+            <div class="guide-panel tracking-archive-panel">
               <div class="section-header-row">
-                <h2>Bark 通知服务</h2>
+                <h2>单号档案</h2>
+                <div class="panel-user-chip">累计 [[ selectedUserHistoryCount ]] 个</div>
               </div>
 
-              <div class="remote-panel service-panel-body">
-                <div class="tracking-section">
-                  <h3>快递单号设置</h3>
-                  <div class="tracking-input-row">
-                    <label for="trackingNumberInput">快递单号</label>
-                    <div class="tracking-input-controls">
-                      <input
-                        id="trackingNumberInput"
-                        type="text"
-                        v-model="envVars.TRACKING_NUMBER"
-                        placeholder="在此粘贴新的快递单号"
-                      />
-                      <button type="button" class="icon-btn" @click="pasteTrackingNumber" title="粘贴">
-                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 2H8a2 2 0 0 0-2 2v2H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2v-2h2a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2Zm-4 18H4V8h8v12Zm4-4h-2V8a2 2 0 0 0-2-2H8V4h8v12Z"/></svg>
-                      </button>
-                      <button type="button" class="icon-btn" @click="clearTrackingNumber" title="清空">
-                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18v2H3V6Zm2 3h14l-1.2 11.2A2 2 0 0 1 15.8 22H8.2a2 2 0 0 1-2-1.8L5 9Zm5-6h4l1 1h5v2H4V4h5l1-1Z"/></svg>
-                      </button>
-                      <button type="button" class="refresh-btn apply-tracking" @click="saveEnv">应用</button>
-                    </div>
-                    <div class="tracking-input-hint">点击“应用”后更新环境变量</div>
-                  </div>
+              <div v-if="selectedUserHistory.length" class="tracking-history-list">
+                <div v-for="item in selectedUserHistory" :key="item.tracking_number + '-' + item.last_seen_at" class="tracking-history-item">
+                  <strong>[[ item.tracking_number ]]</strong>
+                  <span>首次登记 [[ item.first_seen_at ]]</span>
+                  <span>最近保存 [[ item.last_seen_at ]]</span>
                 </div>
-                <div class="remote-header">
-                  <h3>远程 Bark Server 状态</h3>
-                </div>
-                <div class="remote-refresh-row">
-                  <div class="remote-refresh-toggle">
-                    <button
-                      type="button"
-                      :class="['tab-btn', { active: remoteRefreshMode === 'auto' }]"
-                      @click="remoteRefreshMode = 'auto'"
-                    >自动刷新</button>
-                    <button
-                      type="button"
-                      :class="['tab-btn', { active: remoteRefreshMode === 'manual' }]"
-                      @click="remoteRefreshMode = 'manual'"
-                    >手动刷新</button>
-                  </div>
-                  <div class="remote-refresh-right">
-                    <button
-                      v-if="remoteRefreshMode === 'manual'"
-                      type="button"
-                      class="refresh-btn full"
-                      @click="fetchRemoteBarkStatus"
-                      :disabled="remoteBark.loading"
-                    >刷新</button>
-                    <div v-else class="remote-refresh-interval">
-                      <span>间隔</span>
-                      <input type="number" min="0" v-model.number="remoteAutoMinDraft" class="time-input" /> 分
-                      <input type="number" min="0" max="59" v-model.number="remoteAutoSecDraft" class="time-input" /> 秒
-                      <button
-                        type="button"
-                        class="refresh-btn apply-btn"
-                        @click="applyRemoteAutoInterval"
-                      >保存</button>
+              </div>
+              <div v-else class="section-note empty-history">这个账号还没有保存过历史单号。</div>
+            </div>
+
+            <div class="guide-panel service-summary-panel">
+              <div class="section-header-row">
+                <h2>服务控制</h2>
+                <div class="panel-user-chip">日志已移到单独页面</div>
+              </div>
+
+              <div class="service-summary-grid">
+                <div class="service-summary-card">
+                  <div class="section-header-row compact">
+                    <h3>追踪脚本</h3>
+                    <div class="status-group">
+                      <span :class="['status-indicator', { running: script.running, stopped: !script.running }]"></span>
+                      <span class="status-label">[[ script.running ? '运行中' : '未启动' ]]</span>
                     </div>
                   </div>
-                </div>
-                <div class="remote-health-config">
-                  <label for="remoteHealthPath">健康检测路径</label>
-                  <div class="remote-health-row">
-                    <input
-                      id="remoteHealthPath"
-                      type="text"
-                      v-model="envVars.BARK_HEALTH_PATH"
-                      placeholder="/ 或 /health"
-                    />
-                    <button type="button" class="refresh-btn" @click="saveEnv">保存</button>
+                  <p class="field-hint">当前有 [[ trackedUsersCount ]] 个账号启用追踪。脚本不会再在 Web 启动时自动开始。</p>
+                  <div class="portal-actions dual compact-actions">
+                    <button @click="startScript" :disabled="script.running" class="start">启动脚本</button>
+                    <button @click="stopScript" :disabled="!script.running" class="stop">停止脚本</button>
                   </div>
-                  <div class="remote-health-hint">
-                    用于本页面远程状态检测，不影响 Render 设置
-                  </div>
-                </div>
-                <div v-if="remoteBark.loading" class="remote-line">正在检查...</div>
-                <div v-else>
-                  <div class="remote-line">
-                    <span class="remote-label">地址:</span>
-                    <span>[[ remoteBark.url || '未配置' ]]</span>
-                  </div>
-                  <div class="remote-line">
-                    <span class="remote-label">状态:</span>
-                    <span :class="['remote-status', { ok: remoteBark.ok, bad: !remoteBark.ok }]">
-                      [[ remoteBark.ok ? '在线' : '离线/冷启动中' ]]
-                    </span>
-                    <span v-if="remoteBark.status_code">（HTTP [[ remoteBark.status_code ]]）</span>
-                  </div>
-                  <div class="remote-line" v-if="remoteBark.latency_ms !== null">
-                    <span class="remote-label">延迟:</span>
-                    <span>[[ remoteBark.latency_ms ]] ms</span>
-                  </div>
-                  <div class="remote-line" v-if="remoteBark.error">
-                    <span class="remote-label">错误:</span>
-                    <span class="remote-error">[[ remoteBark.error ]]</span>
-                  </div>
-                  <div class="remote-line" v-if="remoteBark.checked_at">
-                    <span class="remote-label">上次检查:</span>
-                    <span>[[ remoteBark.checked_at ]]</span>
+                  <div class="service-summary-note" v-if="keepalive.configured">
+                    保活 [[ keepalive.running ? '已启用' : '未启用' ]] · [[ keepalive.url ]]
                   </div>
                 </div>
 
+                <div class="service-summary-card">
+                  <div class="section-header-row compact">
+                    <h3>Bark 服务</h3>
+                    <div class="status-group">
+                      <span :class="['status-indicator', { running: bark.running, stopped: !bark.running }]"></span>
+                      <span class="status-label">[[ bark.running ? '运行中' : '未启动' ]]</span>
+                    </div>
+                  </div>
+                  <div class="portal-actions dual compact-actions">
+                    <button @click="startBarkServer" :disabled="bark.running" class="start">启动 Bark</button>
+                    <button @click="stopBarkServer" :disabled="!bark.running" class="stop">停止 Bark</button>
+                  </div>
+                  <div class="remote-panel service-panel-body compact-remote">
+                    <div class="section-header-row compact">
+                      <h3>公网健康状态</h3>
+                      <button type="button" class="refresh-btn compact-btn" @click="fetchRemoteBarkStatus" :disabled="remoteBark.loading">刷新</button>
+                    </div>
+                    <div v-if="remoteBark.loading" class="remote-line">正在检查...</div>
+                    <div v-else>
+                      <div class="remote-line">
+                        <span class="remote-label">公网:</span>
+                        <span>[[ remoteBark.url || barkHelp.public_url || '未配置' ]]</span>
+                      </div>
+                      <div class="remote-line">
+                        <span class="remote-label">本机:</span>
+                        <span>[[ barkHelp.internal_url || '未配置' ]]</span>
+                      </div>
+                      <div class="remote-line">
+                        <span class="remote-label">状态:</span>
+                        <span :class="['remote-status', { ok: remoteBark.ok, bad: !remoteBark.ok }]">
+                          [[ remoteBark.ok ? (remoteBark.fallback_used ? '在线(本机回退)' : '在线') : '离线/冷启动中' ]]
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -193,63 +196,270 @@
       </div>
 
       <div class="section" v-if="page === 'env'">
-        <h2>环境变量配置</h2>
+        <div class="hero-surface compact">
+          <div class="hero-grid single-pane">
+            <div class="hero-copy">
+              <div class="eyebrow">System Layer</div>
+              <h2 class="hero-title">这里只放系统级地址与服务参数</h2>
+              <p class="hero-subtitle">用户自己的单号、Bark keys 和个人推送参数都不在这里改，避免全局配置和用户数据混在一起。</p>
+            </div>
+            <div class="hero-metrics summary-strip single">
+              <div class="hero-metric">
+                <span class="hero-metric-label">当前公网 Bark</span>
+                <strong class="metric-url">[[ barkHelp.public_url || '未配置' ]]</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <h2>系统设置</h2>
+        <div class="section-note">这里编辑的是全局 `.env`。用户自己的单号、Bark Keys 和推送参数不在这里改。</div>
         <form @submit.prevent="saveEnv" class="env-form">
           <template v-for="(value, key) in envVars" :key="key">
-            <div v-if="key !== 'TRACKING_NUMBER' && key !== 'BARK_URL_ENABLED' && key !== 'CHECK_INTERVAL' && key !== 'BARK_QUERY_PARAMS' && key !== 'BARK_HEALTH_PATH'">
-              <label :for="key">[[ key ]] ([[ envDesc[key] ]]):</label>
+            <div class="env-field-card">
+              <label :for="key">[[ key ]] ([[ envDesc[key] || '系统配置' ]])</label>
               <input type="text" :id="key" v-model="envVars[key]" />
             </div>
           </template>
-
-          <div v-if="envVars['CHECK_INTERVAL'] !== undefined">
-            <label>CHECK_INTERVAL ([[ envDesc['CHECK_INTERVAL'] ]])</label>
-            <div class="inline-field">
-              <input type="number" min="0" v-model.number="intervalMin" class="time-input" /> 分
-              <input type="number" min="0" max="59" v-model.number="intervalSec" class="time-input" /> 秒
-            </div>
+          <div class="env-actions">
+            <button type="submit" class="env-save-btn">保存系统设置</button>
           </div>
-
-          <div class="mb-3">
-            <label for="BARK_URL_ENABLED">BARK_URL_ENABLED ([[ envDesc['BARK_URL_ENABLED'] ]])</label>
-            <input type="checkbox" id="BARK_URL_ENABLED" v-model="includeUrl" />
-          </div>
-
-          <div v-if="envVars['BARK_QUERY_PARAMS'] !== undefined" class="bark-params">
-            <label for="BARK_QUERY_PARAMS">BARK_QUERY_PARAMS ([[ envDesc['BARK_QUERY_PARAMS'] ]])</label>
-            <input type="text" id="BARK_QUERY_PARAMS" v-model="envVars['BARK_QUERY_PARAMS']" class="param-input" />
-            <div class="param-desc">下表用于逐项编辑，与上方字符串等同</div>
-            <table class="param-table">
-              <tr v-for="(val, param) in barkParams" :key="param">
-                <td class="param-name">[[ param ]]</td>
-                <td class="param-desc">[[ paramOptions[param].description ]]</td>
-                <td>
-                  <select v-if="paramOptions[param].values.length" v-model="barkParams[param]" class="param-input">
-                    <option v-for="item in paramOptions[param].values" :key="item.value" :value="item.value">[[ item.label ]]</option>
-                  </select>
-                  <input v-else type="text" v-model="barkParams[param]" class="param-input" />
-                </td>
-                <td><button type="button" @click="removeParam(param)">删除</button></td>
-              </tr>
-              <tr class="param-add">
-                <td colspan="2">
-                  <select v-model="newParam" class="param-input">
-                    <option disabled value="">选择参数</option>
-                    <option v-for="(opt, key) in availableParams" :key="key" :value="key">[[ key ]] - [[ opt.description ]]</option>
-                  </select>
-                </td>
-                <td><button type="button" @click="addParam" :disabled="!newParam">添加参数</button></td>
-                <td></td>
-              </tr>
-            </table>
-          </div>
-
-          <button type="submit">保存环境变量</button>
         </form>
         <div v-if="envMessage.text" :class="['message', envMessage.type]">[[ envMessage.text ]]</div>
       </div>
 
+      <div class="section" v-if="page === 'users'">
+        <div class="hero-surface compact">
+          <div class="hero-grid single-pane">
+            <div class="hero-copy">
+              <div class="eyebrow">Accounts</div>
+              <h2 class="hero-title">管理员控制账号权限，普通用户只维护自己的投递信息</h2>
+              <p class="hero-subtitle">这里创建和修改账户、开关登录能力、启用追踪、代发测试推送。普通用户看不到这一区域。</p>
+            </div>
+            <div class="hero-metrics summary-strip">
+              <div class="hero-metric">
+                <span class="hero-metric-label">总账号</span>
+                <strong>[[ users.length ]]</strong>
+              </div>
+              <div class="hero-metric">
+                <span class="hero-metric-label">可登录</span>
+                <strong>[[ loginUsersCount ]]</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="section-header-row">
+          <h2>用户管理</h2>
+          <div class="panel-user-chip">总用户 [[ users.length ]] 人</div>
+        </div>
+
+        <div class="users-layout">
+          <div class="users-sidebar">
+            <h3>账号列表</h3>
+            <div class="user-list">
+              <button
+                v-for="user in users"
+                :key="user.id"
+                type="button"
+                :class="['user-card', { active: selectedUserId === user.id }]"
+                @click="selectUser(user.id)"
+              >
+                <div class="user-card-top">
+                  <strong>[[ user.display_name ]]</strong>
+                  <span class="user-badge">[[ user.role ]]</span>
+                </div>
+                <div class="user-card-line">用户名：[[ user.username ]]</div>
+                <div class="user-card-line">追踪：[[ user.tracking_enabled ? '开' : '关' ]] / 登录：[[ user.login_enabled ? '开' : '关' ]]</div>
+                <div class="user-card-line">当前单号：[[ user.tracking_number || '未填写' ]]</div>
+                <div class="user-card-line">历史单号：[[ user.tracking_history_count || 0 ]] 个</div>
+                <div class="user-card-line">多端 Keys：[[ user.bark_keys_masked || '未设置' ]]</div>
+                <div class="user-card-line">最近推送：[[ user.last_push_at || '-' ]]</div>
+              </button>
+            </div>
+
+            <div class="users-create">
+              <div class="section-header-row compact">
+                <h3>创建账号</h3>
+                <button type="button" class="refresh-btn compact-btn" @click="createUserExpanded = !createUserExpanded">
+                  [[ createUserExpanded ? '收起' : '展开' ]]
+                </button>
+              </div>
+
+              <div v-if="createUserExpanded" class="users-create-body">
+                <div class="users-create-grid">
+                  <div>
+                    <label for="createUsername">用户名</label>
+                    <input id="createUsername" type="text" v-model="newUserForm.username" />
+                  </div>
+                  <div>
+                    <label for="createDisplayName">显示名称</label>
+                    <input id="createDisplayName" type="text" v-model="newUserForm.display_name" />
+                  </div>
+                  <div>
+                    <label for="createPassword">初始密码</label>
+                    <input id="createPassword" type="password" v-model="newUserForm.password" />
+                  </div>
+                  <div>
+                    <label for="createRole">角色</label>
+                    <select id="createRole" v-model="newUserForm.role" class="param-input">
+                      <option value="user">user</option>
+                      <option value="admin">admin</option>
+                    </select>
+                  </div>
+                  <div class="full">
+                    <label class="checkbox-row"><input type="checkbox" v-model="newUserForm.login_enabled" /> 允许登录</label>
+                  </div>
+                  <div class="full">
+                    <label class="checkbox-row"><input type="checkbox" v-model="newUserForm.tracking_enabled" /> 启用追踪</label>
+                  </div>
+                </div>
+                <div class="users-create-actions">
+                  <button type="button" class="refresh-btn full" @click="createUser" :disabled="!newUserForm.username.trim() || !newUserForm.password.trim()">创建账号</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="users-editor" v-if="selectedUserId">
+            <div class="editor-header">
+              <h3>账号详情</h3>
+              <div :class="['status-badge', selectedUserTrackingState.tone]">[[ selectedUserTrackingState.label ]]</div>
+            </div>
+
+            <div class="user-insight-grid" v-if="selectedUser">
+              <div class="user-insight-card">
+                <span class="hero-metric-label">当前单号</span>
+                <strong>[[ selectedUser.tracking_number || '未填写' ]]</strong>
+              </div>
+              <div class="user-insight-card">
+                <span class="hero-metric-label">历史单号</span>
+                <strong>[[ selectedUserHistoryCount ]]</strong>
+              </div>
+              <div class="user-insight-card">
+                <span class="hero-metric-label">最近推送</span>
+                <strong>[[ selectedUser.last_push_at || '未推送' ]]</strong>
+              </div>
+              <div class="user-insight-card">
+                <span class="hero-metric-label">最近物流</span>
+                <strong>[[ selectedUser.last_error || selectedUser.last_tracking_info || '暂无记录' ]]</strong>
+              </div>
+            </div>
+
+            <div class="user-form-grid">
+              <div>
+                <label for="userUsername">用户名</label>
+                <input id="userUsername" type="text" v-model="userForm.username" />
+              </div>
+              <div>
+                <label for="userDisplayName">显示名称</label>
+                <input id="userDisplayName" type="text" v-model="userForm.display_name" />
+              </div>
+              <div>
+                <label for="userRole">角色</label>
+                <select id="userRole" v-model="userForm.role" class="param-input">
+                  <option value="user">user</option>
+                  <option value="admin">admin</option>
+                </select>
+              </div>
+              <div>
+                <label for="userCheckInterval">查询间隔（秒）</label>
+                <input id="userCheckInterval" type="number" min="30" v-model.number="userForm.check_interval" />
+              </div>
+              <div class="full">
+                <label for="userNote">备注</label>
+                <input id="userNote" type="text" v-model="userForm.note" />
+              </div>
+              <div class="full">
+                <label for="userTrackingNumber">日本邮政单号</label>
+                <input id="userTrackingNumber" type="text" v-model="userForm.tracking_number" />
+                <p class="field-hint">该用户启用追踪后，后台会按独立间隔轮询这个单号。</p>
+              </div>
+              <div class="full">
+                <label for="userBarkKeys">Bark Keys（支持多端，一行一个）</label>
+                <textarea id="userBarkKeys" v-model="userForm.bark_keys" rows="5"></textarea>
+                <p class="field-hint">支持直接粘贴完整推送 URL。多端推送时，一行放一个设备 key。</p>
+              </div>
+              <div class="full">
+                <label for="userBarkQueryParams">Bark 参数</label>
+                <input id="userBarkQueryParams" type="text" v-model="userForm.bark_query_params" />
+              </div>
+              <div class="full">
+                <div class="test-panel">
+                  <div class="test-panel-header">
+                    <h3>Bark 预览</h3>
+                    <p class="field-hint">测试会直接使用当前编辑器里的 Bark Keys、参数和追踪链接开关，不需要先保存账号。</p>
+                  </div>
+                  <div class="test-grid">
+                    <div>
+                      <label for="userTestTitle">测试标题</label>
+                      <input id="userTestTitle" type="text" v-model="userForm.test_title" />
+                    </div>
+                    <div class="full">
+                      <label for="userTestBody">测试内容</label>
+                      <textarea id="userTestBody" v-model="userForm.test_body" rows="4"></textarea>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <label class="checkbox-row"><input type="checkbox" v-model="userForm.bark_url_enabled" /> 推送附带追踪链接</label>
+              </div>
+              <div>
+                <label class="checkbox-row"><input type="checkbox" v-model="userForm.login_enabled" /> 允许登录</label>
+              </div>
+              <div>
+                <label class="checkbox-row"><input type="checkbox" v-model="userForm.tracking_enabled" /> 启用追踪</label>
+              </div>
+              <div class="full">
+                <label for="userNewPassword">重置密码（留空不修改）</label>
+                <input id="userNewPassword" type="password" v-model="userForm.new_password" />
+              </div>
+            </div>
+
+            <div class="portal-actions dual">
+              <button type="button" class="env-save-btn" @click="saveUser" :disabled="!userForm.username.trim()">保存账号</button>
+              <button type="button" class="refresh-btn" @click="sendUserTestPush" :disabled="sendingTestPush">发送 Bark 测试</button>
+            </div>
+            <div v-if="userMessage.text" :class="['message', userMessage.type]">[[ userMessage.text ]]</div>
+
+            <div class="guide-panel slim tracking-archive-panel">
+              <h3>单号档案</h3>
+              <div v-if="selectedUserHistory.length" class="tracking-history-list">
+                <div v-for="item in selectedUserHistory" :key="item.tracking_number + '-' + item.last_seen_at" class="tracking-history-item">
+                  <strong>[[ item.tracking_number ]]</strong>
+                  <span>首次登记 [[ item.first_seen_at ]]</span>
+                  <span>最近保存 [[ item.last_seen_at ]]</span>
+                </div>
+              </div>
+              <div v-else class="section-note empty-history">这个账号还没有保存过历史单号。</div>
+            </div>
+
+            <div class="guide-panel slim">
+              <h3>Bark 配置说明</h3>
+              <ol class="guide-list">
+                <li>用户登录后只看到自己的“我的快递与 Bark 设置”页面。</li>
+                <li>服务器地址填 `[[ barkHelp.public_url || barkHelp.internal_url || '未配置' ]]`。</li>
+                <li>多端推送时，每个设备都要单独复制一个 key，然后一行填一个。</li>
+                <li>这里可以直接粘贴完整推送 URL，后端会自动提取 key。</li>
+                <li>“发送 Bark 测试”会使用当前编辑器里的 Bark 参数和测试文案直接预览效果。</li>
+              </ol>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="section" v-if="page === 'logs'">
+        <div class="hero-surface compact">
+          <div class="hero-grid single-pane">
+            <div class="hero-copy">
+              <div class="eyebrow">Observability</div>
+              <h2 class="hero-title">把实时输出和历史排障痕迹放在同一个观察层</h2>
+              <p class="hero-subtitle">Remote Bark、Tracker 和 Bark Server 的流式日志都会收进这里，便于确认每个用户和每个服务的状态。</p>
+            </div>
+          </div>
+        </div>
+
         <h2>日志</h2>
         <div class="tab-bar logs-tabbar">
           <button type="button" :class="['tab-btn', { active: logTab === 'remote' }]" @click="logTab = 'remote'">Remote Bark</button>
@@ -278,14 +488,16 @@
       </div>
     </div>
 
-    <script id="initial-env" type="application/json">
-      {{ env_vars | tojson | safe }}
-    </script>
+    <script id="initial-env" type="application/json">{{ env_vars | tojson | safe }}</script>
+    <script id="initial-user-state" type="application/json">{{ user_state | tojson | safe }}</script>
+    <script id="initial-viewer-state" type="application/json">{{ viewer_state | tojson | safe }}</script>
+    <script id="initial-bark-help" type="application/json">{{ bark_help | tojson | safe }}</script>
     <script>
       (function () {
-        const el = document.getElementById('initial-env');
-        const text = el ? el.textContent : '{}';
-        window.initialEnvVars = JSON.parse(text || '{}');
+        window.initialEnvVars = JSON.parse((document.getElementById('initial-env') || {}).textContent || '{}');
+        window.initialUserState = JSON.parse((document.getElementById('initial-user-state') || {}).textContent || '{}');
+        window.initialViewerState = JSON.parse((document.getElementById('initial-viewer-state') || {}).textContent || '{}');
+        window.initialBarkHelp = JSON.parse((document.getElementById('initial-bark-help') || {}).textContent || '{}');
       })();
     </script>
     <script src="/static/app.js"></script>

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>登录</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body class="auth-page">
+    <div class="auth-shell auth-single">
+      <div class="auth-card auth-card-simple">
+        <div class="auth-eyebrow">JP Post Tracker</div>
+        <h1 class="auth-single-title">登录</h1>
+        <p class="auth-subtitle">输入用户名和密码后，系统会按你的角色进入管理员后台或个人门户。</p>
+
+        {% if error %}
+        <div class="message error">{{ error }}</div>
+        {% endif %}
+
+        <form method="post" class="auth-form">
+          <input type="hidden" name="next" value="{{ next_target }}" />
+
+          <label for="username">用户名</label>
+          <input id="username" name="username" type="text" autocomplete="username" placeholder="输入用户名" required />
+
+          <label for="password">密码</label>
+          <input id="password" name="password" type="password" autocomplete="current-password" placeholder="输入密码" required />
+
+          <button type="submit">登录</button>
+        </form>
+
+        <div class="auth-link-row">
+          <span>还没有普通用户账号？</span>
+          <a href="{{ url_for('register', next=next_target) }}">去注册</a>
+        </div>
+
+        <div class="auth-help">
+          当前管理员引导用户名：<code>{{ admin_username }}</code>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/templates/register.html
+++ b/src/templates/register.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>注册普通用户</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body class="auth-page">
+    <div class="auth-shell auth-single">
+      <div class="auth-card auth-card-simple">
+        <div class="auth-eyebrow">Create Account</div>
+        <h1 class="auth-single-title">注册普通用户</h1>
+        <p class="auth-subtitle">注册后只会看到自己的快递与 Bark 设置页，不会看到管理员的系统控制功能。</p>
+
+        {% if error %}
+        <div class="message error">{{ error }}</div>
+        {% endif %}
+
+        <form method="post" action="/register" class="auth-form">
+          <input type="hidden" name="next" value="{{ next_target }}" />
+
+          <label for="register_display_name">显示名称</label>
+          <input
+            id="register_display_name"
+            name="register_display_name"
+            type="text"
+            autocomplete="name"
+            placeholder="例如 张三 / 家人共用账号"
+            required
+          />
+
+          <label for="register_username">用户名</label>
+          <input
+            id="register_username"
+            name="register_username"
+            type="text"
+            autocomplete="username"
+            placeholder="仅支持小写字母、数字、点、下划线、短横线"
+            required
+          />
+
+          <label for="register_password">密码</label>
+          <input
+            id="register_password"
+            name="register_password"
+            type="password"
+            autocomplete="new-password"
+            placeholder="设置登录密码"
+            required
+          />
+
+          <button type="submit">注册并登录</button>
+        </form>
+
+        <div class="auth-link-row">
+          <span>已经有账号了？</span>
+          <a href="{{ url_for('login', next=next_target) }}">返回登录</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/templates/user_portal.html
+++ b/src/templates/user_portal.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>我的快递与 Bark 设置</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body class="portal-page">
+    <div class="container">
+      <div class="header">
+        <div class="header-copy">
+          <div class="eyebrow">My Delivery Space</div>
+          <h1>我的快递与 Bark 设置</h1>
+          <p class="page-copy">这里只管理你自己的单号、Bark 设备 key 和测试推送，不会暴露其他用户或系统控制能力。</p>
+        </div>
+        <form method="post" action="/logout" class="logout-form header-session">
+          <span class="current-user">{{ viewer_state.display_name }} · {{ viewer_state.username }}</span>
+          <button type="submit" class="ghost-btn">退出登录</button>
+        </form>
+      </div>
+
+      {% if message %}
+      <div class="message {{ status }}">{{ message }}</div>
+      {% endif %}
+
+      <div class="hero-surface compact">
+        <div class="hero-grid portal-hero-grid">
+          <div class="hero-copy">
+            <div class="eyebrow">Personal Tracking</div>
+            <h2 class="hero-title">把你的单号、推送设备和历史档案收进一块私有面板</h2>
+            <p class="hero-subtitle">
+              每个设备都需要单独注册自己的 Bark key。如果你想多端同时收到同一条消息，就把多个 key 一行一个填进来。
+            </p>
+            <div class="hero-pill-row">
+              <span class="hero-pill">账号 {{ viewer_state.username }}</span>
+              <span class="hero-pill">{{ 'Bark 已配置' if account.bark_keys else 'Bark 未配置' }}</span>
+              <span class="hero-pill">{{ '追踪启用中' if account.tracking_enabled else '追踪已关闭' }}</span>
+            </div>
+          </div>
+
+          <div class="hero-metrics">
+            <div class="hero-metric">
+              <span class="hero-metric-label">当前单号</span>
+              <strong>{{ account.tracking_number or '未填写' }}</strong>
+            </div>
+            <div class="hero-metric">
+              <span class="hero-metric-label">历史单号</span>
+              <strong>{{ account.tracking_history_count or 0 }}</strong>
+            </div>
+            <div class="hero-metric">
+              <span class="hero-metric-label">最近推送</span>
+              <strong>{{ account.last_push_at or '未推送' }}</strong>
+            </div>
+            <div class="hero-metric">
+              <span class="hero-metric-label">最近物流</span>
+              <strong>{{ account.last_error or account.last_tracking_info or '暂无记录' }}</strong>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="section user-portal-grid">
+        <div class="users-editor">
+          <div class="editor-header">
+            <h2>我的资料</h2>
+          </div>
+          <form method="post" action="/me/update">
+            <div class="user-form-grid">
+              <div>
+                <label for="display_name">显示名称</label>
+                <input id="display_name" name="display_name" type="text" value="{{ account.display_name }}" />
+              </div>
+              <div>
+                <label for="username">登录用户名</label>
+                <input id="username" type="text" value="{{ account.username }}" disabled />
+              </div>
+              <div class="full">
+                <label for="note">备注</label>
+                <input id="note" name="note" type="text" value="{{ account.note }}" />
+              </div>
+              <div class="full">
+                <label for="tracking_number">日本邮政单号</label>
+                <input id="tracking_number" name="tracking_number" type="text" value="{{ account.tracking_number }}" />
+                <p class="field-hint">填写日本邮政单号后，系统会按设定间隔为你单独轮询并写回最近状态。</p>
+              </div>
+              <div>
+                <label for="check_interval">查询间隔（秒）</label>
+                <input id="check_interval" name="check_interval" type="number" min="30" value="{{ account.check_interval }}" />
+              </div>
+              <div>
+                <label for="bark_url_enabled">推送里附带追踪链接</label>
+                <input id="bark_url_enabled" name="bark_url_enabled" type="checkbox" {% if account.bark_url_enabled %}checked{% endif %} />
+              </div>
+              <div class="full">
+                <label for="bark_keys">Bark Keys（支持多端，一行一个）</label>
+                <textarea id="bark_keys" name="bark_keys" rows="5" placeholder="可以粘贴完整推送 URL，也可以只填 key">{{ account.bark_keys }}</textarea>
+                <p class="field-hint">支持直接粘贴完整推送 URL，系统会自动提取 key。多设备同时推送时，一行放一个 key。</p>
+              </div>
+              <div class="full">
+                <label for="bark_query_params">Bark 参数</label>
+                <input id="bark_query_params" name="bark_query_params" type="text" value="{{ account.bark_query_params }}" />
+                <p class="field-hint">例如 `?sound=minuet&level=timeSensitive`。这里会附加到每条 Bark 推送请求上。</p>
+              </div>
+              <div class="full">
+                <div class="test-panel">
+                  <div class="test-panel-header">
+                    <h3>Bark 预览</h3>
+                    <p class="field-hint">这里会直接使用你当前表单里的 Bark Keys、参数和“附带追踪链接”开关发一条测试消息，不需要先保存。</p>
+                  </div>
+                  <div class="test-grid">
+                    <div>
+                      <label for="test_title">测试标题</label>
+                      <input id="test_title" name="test_title" type="text" value="测试推送" />
+                    </div>
+                    <div class="full">
+                      <label for="test_body">测试内容</label>
+                      <textarea id="test_body" name="test_body" rows="4">这是 Bark 参数预览消息，用来确认通知样式、声音和链接效果。</textarea>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="full">
+                <label for="new_password">新密码（留空表示不修改）</label>
+                <input id="new_password" name="new_password" type="password" autocomplete="new-password" />
+              </div>
+            </div>
+
+            <div class="portal-actions dual">
+              <button type="submit" class="env-save-btn">保存资料</button>
+              <button type="submit" class="refresh-btn" formaction="/me/test-push" formmethod="post">发送 Bark 测试</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="portal-side-column">
+          <div class="guide-panel tracking-archive-panel">
+            <h2>单号档案</h2>
+            {% if account.tracking_history %}
+            <div class="tracking-history-list">
+              {% for item in account.tracking_history %}
+              <div class="tracking-history-item">
+                <strong>{{ item.tracking_number }}</strong>
+                <span>首次登记 {{ item.first_seen_at }}</span>
+                <span>最近保存 {{ item.last_seen_at }}</span>
+              </div>
+              {% endfor %}
+            </div>
+            {% else %}
+            <div class="section-note empty-history">你还没有保存过历史单号。</div>
+            {% endif %}
+          </div>
+
+          <div class="guide-panel">
+          <h2>Bark 设置手顺</h2>
+          <div class="guide-steps">
+            <div class="guide-step">
+              <span class="guide-step-no">01</span>
+              <div>
+                <strong>配置服务器地址</strong>
+                <p>在 iPhone / iPad 上安装 Bark，把服务器地址设为 <code>{{ bark_help.public_url or bark_help.internal_url or '未配置' }}</code>。</p>
+              </div>
+            </div>
+            <div class="guide-step">
+              <span class="guide-step-no">02</span>
+              <div>
+                <strong>复制推送 URL 或 key</strong>
+                <p>打开 Bark 后复制测试推送 URL。你可以把整条 URL 直接粘贴到 `Bark Keys`，系统会自动提取 key。</p>
+              </div>
+            </div>
+            <div class="guide-step">
+              <span class="guide-step-no">03</span>
+              <div>
+                <strong>需要多端时逐个登记</strong>
+                <p>每个设备都有自己的 key。想让同一条消息同时推送到多个终端，就把多个设备的 key 一行一个填进去。</p>
+              </div>
+            </div>
+            <div class="guide-step">
+              <span class="guide-step-no">04</span>
+              <div>
+                <strong>保存并测试</strong>
+                <p>你可以直接点“发送 Bark 测试”，预览当前参数的实际效果。若只想看服务在线，可访问 <code>{{ bark_help.public_url }}{{ bark_help.health_path }}</code>。</p>
+              </div>
+            </div>
+          </div>
+          <div class="section-note">
+            注意：同一个 Bark key 对应的是一个已注册设备。多端推送不是“一个 key 自动广播到所有设备”，而是需要把多个设备各自的 key 都填进来。
+          </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/tracker.py
+++ b/src/tracker.py
@@ -1,15 +1,21 @@
 import os
 import time
 import urllib.parse
-from bs4 import BeautifulSoup
-import requests
-from dotenv import load_dotenv # 导入 load_dotenv
 import time as _time
 
-# Load environment variables from .env file
-load_dotenv()
+import requests
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
 
-# 固定时区为日本（如果外部未指定）
+from storage import ensure_storage, list_tracked_accounts, load_system_env, parse_bark_keys, update_tracking_state
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+DOTENV_PATH = os.path.join(BASE_DIR, ".env")
+SYSTEM_ENV_KEYS = ["BARK_SERVER_INTERNAL", "BARK_SERVER", "BARK_SERVER_PUBLIC", "REQUEST_TIMEOUT"]
+
+load_dotenv(DOTENV_PATH)
+ensure_storage(DOTENV_PATH)
+
 os.environ.setdefault("TZ", "Asia/Tokyo")
 if hasattr(_time, "tzset"):
     try:
@@ -17,130 +23,232 @@ if hasattr(_time, "tzset"):
     except Exception:
         pass
 
-# ------------------ 配置区域 ------------------
-# 从 .env 文件中读取配置
-TRACKING_NUMBER = os.getenv("TRACKING_NUMBER")
-TRACKING_URL = f"https://trackings.post.japanpost.jp/services/srv/search/direct?reqCodeNo1={TRACKING_NUMBER}&searchKind=S002&locale=ja"
-CHECK_INTERVAL = int(os.getenv("CHECK_INTERVAL", 300))  # 默认值300秒
 
-# Bark 推送配置
-BARK_SERVER = os.getenv("BARK_SERVER")
-BARK_KEY = os.getenv("BARK_KEY")
-# Bark 额外查询参数，可在网页中配置
-BARK_QUERY_PARAMS = os.getenv("BARK_QUERY_PARAMS", "?sound=minuet&level=timeSensitive")
-# 是否在通知中包含追踪链接
-BARK_URL_ENABLED = os.getenv("BARK_URL_ENABLED", "1")
-# ----------------------------------------------
+def _first_non_empty(*values: str) -> str:
+    for value in values:
+        if value and str(value).strip():
+            return str(value).strip()
+    return ""
 
-def send_bark_notification(title, message):
-    """
-    通过 Bark 推送通知
-    URL 格式: {BARK_SERVER}/{BARK_KEY}/{title}/{message}{BARK_QUERY_PARAMS}
-    如果返回 502，则等待30秒后重新发送
-    """
-    # 将 safe 参数设为空字符串，确保所有字符都被编码
-    title_enc = urllib.parse.quote(title, safe="")
-    message_enc = urllib.parse.quote(message, safe="")
-    # 按需在查询参数中加入追踪链接
-    extra = ''
-    if BARK_URL_ENABLED and BARK_URL_ENABLED != '0':
-        joiner = '&' if BARK_QUERY_PARAMS else '?'
-        extra = f"{joiner}url={urllib.parse.quote(TRACKING_URL, safe='')}"
 
-    url = f"{BARK_SERVER}/{BARK_KEY}/{title_enc}/{message_enc}{BARK_QUERY_PARAMS}{extra}"
+def _normalize_int(value, default: int) -> int:
     try:
-        resp = requests.get(url)
-        if resp.status_code == 200:
-            print("Bark 通知已发送。")
-        else:
-            print(f"Bark 通知发送失败，状态码：{resp.status_code}，等待30秒后重试...")
+        parsed = int(value)
+        return parsed if parsed > 0 else default
+    except Exception:
+        return default
+
+
+def _parse_query_params(query_string: str) -> dict:
+    query_string = str(query_string or "").strip()
+    if not query_string:
+        return {}
+    result = {}
+    for part in query_string.lstrip("?").split("&"):
+        if not part:
+            continue
+        key, _, value = part.partition("=")
+        result[urllib.parse.unquote(key)] = urllib.parse.unquote(value)
+    return result
+
+
+def build_tracking_url(tracking_number: str) -> str:
+    return (
+        "https://trackings.post.japanpost.jp/services/srv/search/direct"
+        f"?reqCodeNo1={tracking_number}&searchKind=S002&locale=ja"
+    )
+
+
+def build_runtime_config(account: dict, system_env: dict) -> dict:
+    tracking_number = str(account.get("tracking_number", "") or "").strip()
+    bark_server = _first_non_empty(
+        system_env.get("BARK_SERVER_INTERNAL"),
+        system_env.get("BARK_SERVER"),
+        system_env.get("BARK_SERVER_PUBLIC"),
+    ).rstrip("/")
+    return {
+        "account_id": account["id"],
+        "username": account.get("username", ""),
+        "display_name": account.get("display_name") or account.get("name") or account.get("username") or "用户",
+        "tracking_number": tracking_number,
+        "tracking_url": build_tracking_url(tracking_number),
+        "check_interval": _normalize_int(account.get("check_interval", 300), 300),
+        "request_timeout": _normalize_int(system_env.get("REQUEST_TIMEOUT", "15"), 15),
+        "bark_server": bark_server,
+        "bark_keys": parse_bark_keys(account.get("bark_keys") or account.get("bark_key")),
+        "bark_query_params": str(account.get("bark_query_params", "") or ""),
+        "bark_url_enabled": bool(account.get("bark_url_enabled")),
+        "last_tracking_info": str(account.get("last_tracking_info", "") or ""),
+    }
+
+
+def validate_config(config: dict) -> list[str]:
+    missing = []
+    if not config["tracking_number"]:
+        missing.append("tracking_number")
+    if not config["bark_server"]:
+        missing.append("bark_server")
+    if not config["bark_keys"]:
+        missing.append("bark_keys")
+    return missing
+
+
+def send_bark_notification(config: dict, title: str, message: str, retries: int = 1) -> bool:
+    if not config["bark_server"] or not config["bark_keys"]:
+        print(f"[{config['display_name']}] 未配置 Bark 地址或 Bark Keys，跳过推送。")
+        return False
+
+    query_params = _parse_query_params(config["bark_query_params"])
+    if config["bark_url_enabled"]:
+        query_params["url"] = config["tracking_url"]
+
+    last_error = ""
+    keys = config["bark_keys"]
+    for attempt in range(retries + 1):
+        try:
+            if len(keys) == 1:
+                title_enc = urllib.parse.quote(title, safe="")
+                body_enc = urllib.parse.quote(message, safe="")
+                extra = urllib.parse.urlencode(query_params, doseq=True)
+                suffix = f"?{extra}" if extra else ""
+                url = f"{config['bark_server']}/{keys[0]}/{title_enc}/{body_enc}{suffix}"
+                resp = requests.get(url, timeout=config["request_timeout"])
+            else:
+                payload = {"title": title, "body": message, "device_keys": keys, **query_params}
+                resp = requests.post(
+                    f"{config['bark_server']}/push",
+                    json=payload,
+                    timeout=config["request_timeout"],
+                )
+
+            if 200 <= resp.status_code < 300:
+                print(f"[{config['display_name']}] Bark 通知已发送到 {len(keys)} 个设备。")
+                return True
+            last_error = f"HTTP {resp.status_code}"
+        except Exception as exc:
+            last_error = str(exc)
+
+        if attempt < retries:
+            print(f"[{config['display_name']}] Bark 发送失败（{last_error}），30 秒后重试。")
             time.sleep(30)
-            send_bark_notification(title, message)
-    except Exception as e:
-        print("发送 Bark 通知时出错：", e)
 
-def get_latest_tracking_info(): # 不再需要 driver 参数
-    """
-    直接使用 requests 获取页面内容并解析最新的物流记录。
-    """
+    print(f"[{config['display_name']}] Bark 通知发送失败：{last_error}")
+    return False
+
+
+def get_latest_tracking_info(config: dict):
     try:
-        # 模拟浏览器头，提高请求成功率
         headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36',
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-            'Accept-Language': 'zh-CN,zh;q=0.9,ja;q=0.8',
-            'Connection': 'keep-alive',
-            'Upgrade-Insecure-Requests': '1',
-            'Sec-Fetch-Dest': 'document',
-            'Sec-Fetch-Mode': 'navigate',
-            'Sec-Fetch-Site': 'none',
-            'Sec-Fetch-User': '?1',
-            'sec-ch-ua': '"Google Chrome";v="137", "Chromium";v="137", "Not/A)Brand";v="24"',
-            'sec-ch-ua-mobile': '?0',
-            'sec-ch-ua-platform': '"macOS"'
-            # 您可以尝试加上 Cookie，但通常首次GET请求不需要，或者网站会设置新的Cookie
-            # 'Cookie': 'JSESSIONID=...; TS01b09507=...'
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+            "Accept-Language": "zh-CN,zh;q=0.9,ja;q=0.8",
+            "Connection": "keep-alive",
+            "Upgrade-Insecure-Requests": "1",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "none",
+            "Sec-Fetch-User": "?1",
+            "sec-ch-ua": '"Google Chrome";v="137", "Chromium";v="137", "Not/A)Brand";v="24"',
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"macOS"',
         }
-        response = requests.get(TRACKING_URL, headers=headers)
-        response.raise_for_status()  # 检查 HTTP 错误
+        response = requests.get(config["tracking_url"], headers=headers, timeout=config["request_timeout"])
+        response.raise_for_status()
 
         soup = BeautifulSoup(response.text, "html.parser")
-
-        # 定位 summary 为 "履歴情報" 的物流信息表格
         table = soup.find("table", {"class": "tableType01 txt_c m_b5", "summary": "履歴情報"})
         if not table:
-            print("未能找到物流信息表格。")
             return None
 
-        # 查找所有日期单元格
         date_cells = table.find_all("td", class_="w_120")
         if not date_cells:
-            print("未能提取到任何物流记录。")
             return None
 
-        # 取最后一个记录作为最新进展
         latest_date = date_cells[-1].get_text(strip=True)
         latest_row = date_cells[-1].parent
         if latest_row is None:
-            print("未能定位到最新物流记录行。")
             return None
         status_cell = latest_row.find("td", class_="w_150")
         latest_status = status_cell.get_text(strip=True) if status_cell else ""
-        latest_info = f"{latest_date} {latest_status}"
-        return latest_info
-    except requests.exceptions.RequestException as e:
-        print(f"请求快递信息失败: {e}")
+        return f"{latest_date} {latest_status}".strip()
+    except requests.exceptions.RequestException as exc:
+        print(f"[{config['display_name']}] 请求快递信息失败: {exc}")
         return None
-    except Exception as e:
-        print(f"解析快递信息时出错: {e}")
+    except Exception as exc:
+        print(f"[{config['display_name']}] 解析快递信息时出错: {exc}")
         return None
+
+
+def process_account(account: dict, system_env: dict):
+    config = build_runtime_config(account, system_env)
+    missing = validate_config(config)
+    if missing:
+        error = f"缺少必要配置: {', '.join(missing)}"
+        print(f"[{config['display_name']}] {error}")
+        update_tracking_state(config["account_id"], error=error)
+        return
+
+    current_info = get_latest_tracking_info(config)
+    if not current_info:
+        update_tracking_state(config["account_id"], error="无法获取最新快递信息。")
+        return
+
+    print(f"[{config['display_name']}] 最新物流记录: {current_info}")
+    pushed = False
+    if current_info != config["last_tracking_info"]:
+        pushed = send_bark_notification(config, "快递更新通知", current_info)
+    else:
+        print(f"[{config['display_name']}] 暂无更新。")
+
+    update_tracking_state(
+        config["account_id"],
+        latest_info=current_info,
+        error="",
+        pushed=pushed,
+    )
+
 
 def main():
-    print("快递监控程序启动...")
+    print("多用户快递监控程序启动...")
+    next_runs = {}
+    last_empty_log_at = 0.0
 
-    last_info = None
     try:
         while True:
-            current_info = get_latest_tracking_info()
-            if current_info:
-                print("最新物流记录：", current_info)
-                # 首次获取到物流信息时直接发送通知
-                if last_info is None:
-                    send_bark_notification("快递更新通知", current_info)
-                    last_info = current_info
-                elif current_info != last_info:
-                    print("检测到快递进展更新！")
-                    send_bark_notification("快递更新通知", current_info)
-                    last_info = current_info
-                else:
-                    print(f"暂无更新。 当前时间: {time.strftime('%Y-%m-%d %H:%M:%S')}")
-            else:
-                print("无法获取最新快递信息。")
-            time.sleep(CHECK_INTERVAL)
+            accounts = list_tracked_accounts()
+            now = time.time()
+
+            if not accounts:
+                if now - last_empty_log_at >= 60:
+                    print("当前没有启用追踪的用户。")
+                    last_empty_log_at = now
+                time.sleep(5)
+                continue
+
+            account_ids = {account["id"] for account in accounts}
+            for stale_id in list(next_runs.keys()):
+                if stale_id not in account_ids:
+                    next_runs.pop(stale_id, None)
+
+            due_accounts = []
+            for account in accounts:
+                next_run = next_runs.get(account["id"], 0)
+                if now >= next_run:
+                    due_accounts.append(account)
+
+            if not due_accounts:
+                time.sleep(1)
+                continue
+
+            system_env = load_system_env(DOTENV_PATH, SYSTEM_ENV_KEYS)
+            for account in due_accounts:
+                process_account(account, system_env)
+                next_runs[account["id"]] = time.time() + _normalize_int(account.get("check_interval", 300), 300)
+
+            time.sleep(1)
     except KeyboardInterrupt:
         print("程序终止。")
-    finally:
-        pass
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## 概要
将 jppost-tracker 从单功能改造为支持多用户和树莓派本地部署的版本。

## 主要改动
- **用户系统**：新增登录/注册/用户门户页面及 `storage.py` 用户存储
- **页面重构**：改为 tab 分页式，新增 log 查阅分页，适配手机尺寸
- **树莓派部署**：新增 systemd service 示例、部署文档、bark-server docker wrapper 脚本
- **依赖调整**：bark-server 由 eventlet 切换为 gevent

## 提交
1. 增加树莓派本地funnel部署支持，bark-server切换gevent
2. 增加用户登录注册系统，页面改为tab分页式并适配手机尺寸
3. 更新README及树莓派部署文档